### PR TITLE
fix: Use `flyctl` instead of `fly` in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+  pull_request:
 jobs:
   deploy:
     name: Deploy app to fly.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - main
-  pull_request:
 jobs:
   deploy:
     name: Deploy app to fly.io

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ci: cluster  ## Run Tilt in CI mode
 short_commit ?= $(shell git log -1 --pretty=%H | cut -c -7)
 
 deploy:
-	fly deploy \
+	flyctl deploy \
 		-e SENTRY_RELEASE=$(short_commit) \
 		-e APP_REVISION=$(short_commit)
 


### PR DESCRIPTION
The GitHub Actions workflow uses `flyctl`, and that is working for me locally, so unifying them under the same `make deploy` target.