### PR TITLE
chore: Enable auto-merge for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,20 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>anaconda/renovate-config"]
+  "extends": ["github>anaconda/renovate-config"],
+  "packageRules": [
+    {
+      "description": "Auto-merge minor and patch updates when CI passes",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Auto-merge pre-commit hook updates",
+      "matchManagers": ["pre-commit"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enable auto-merge for Renovate dependency update PRs when CI passes.

- Minor, patch, pin, and digest updates will auto-merge
- Pre-commit hook updates will auto-merge

**Note:** For this to work, "Allow auto-merge" must be enabled in the repo settings (Settings → General → Pull Requests → Allow auto-merge).

## Test plan

- [ ] Verify Renovate config is valid
- [ ] Check that next Renovate PR has auto-merge enabled