### PR TITLE
chore: Simplify Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>anaconda/renovate-config"],
+  "commitMessageLowerCase": "never",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
   "packageRules": [
     {
-      "description": "Auto-merge minor and patch updates when CI passes",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
+      "description": "Auto-merge minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
     },
     {
       "description": "Auto-merge pre-commit hook updates",
       "matchManagers": ["pre-commit"],
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replace `github>anaconda/renovate-config` with `config:recommended` to simplify the Renovate configuration and remove the external dependency.

Changes:
- Use `config:recommended` base preset
- Add `helpers:pinGitHubActionDigestsToSemver` for GHA digest pinning
- Enable lock file maintenance with auto-merge
- Simplify package rules

This matches the pattern used in lembas-cli.