### PR TITLE
feat(auth): Add device flow authentication for CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ __pycache__/
 
 # Generated build artifacts
 static/css/output.css
+
+# Local SQLite database
+*.db
+
+# Artifacts directory
+artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,5 @@ __pycache__/
 # Generated build artifacts
 static/css/output.css
 
-# Local SQLite database
-*.db
-
-# Artifacts directory
-artifacts/
+# Local data directory (database, artifacts)
+/data/

--- a/app/auth.py
+++ b/app/auth.py
@@ -4,6 +4,16 @@ from app.models import User
 from app.settings import Settings
 
 
+class GitHubUserData:
+    """Raw GitHub user data."""
+
+    def __init__(self, data: dict):
+        self.id: int = data["id"]
+        self.login: str = data["login"]
+        self.name: str | None = data.get("name")
+        self.avatar_url: str = data.get("avatar_url", "")
+
+
 async def exchange_code_for_token(code: str, config: Settings) -> str | None:
     """Retrieve an access token based on the code from the authorization flow."""
     if config.dummy_auth:
@@ -28,7 +38,8 @@ async def exchange_code_for_token(code: str, config: Settings) -> str | None:
     return data.get("access_token")
 
 
-async def get_user_from_token(token: str) -> User:
+async def get_github_user_data(token: str) -> GitHubUserData:
+    """Fetch user data from GitHub API."""
     async with httpx.AsyncClient() as client:
         resp = await client.get(
             "https://api.github.com/user",
@@ -38,5 +49,10 @@ async def get_user_from_token(token: str) -> User:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
-    data = resp.json()
-    return User(**data)
+    return GitHubUserData(resp.json())
+
+
+async def get_user_from_token(token: str) -> User:
+    """Get a User model from a GitHub access token."""
+    data = await get_github_user_data(token)
+    return User(login=data.login, name=data.name, avatar_url=data.avatar_url)

--- a/app/crypto.py
+++ b/app/crypto.py
@@ -1,0 +1,68 @@
+"""Cryptographic utilities for token generation and hashing."""
+
+import hashlib
+import secrets
+from base64 import urlsafe_b64encode
+
+from cryptography.fernet import Fernet
+
+TOKEN_PREFIX = "lb_v1_"
+USER_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+
+def generate_api_token() -> tuple[str, str]:
+    """Generate a new API token.
+
+    Returns:
+        Tuple of (full_token, token_hash) where full_token is shown to user once
+        and token_hash is stored in database.
+    """
+    random_bytes = secrets.token_bytes(32)
+    token = TOKEN_PREFIX + urlsafe_b64encode(random_bytes).decode().rstrip("=")
+    token_hash = hash_token(token)
+    return token, token_hash
+
+
+def hash_token(token: str) -> str:
+    """Hash a token for storage/lookup."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def generate_device_code() -> str:
+    """Generate a random device code."""
+    return secrets.token_urlsafe(32)
+
+
+def generate_user_code() -> str:
+    """Generate a human-readable user code like LMBS-XXXX."""
+    code = "".join(secrets.choice(USER_CODE_CHARS) for _ in range(4))
+    return f"LMBS-{code}"
+
+
+def get_token_prefix(token: str) -> str:
+    """Extract a prefix from a token for identification."""
+    return token[:12] if len(token) >= 12 else token
+
+
+def encrypt_value(value: str, key: str) -> str:
+    """Encrypt a value using Fernet symmetric encryption."""
+    if not key:
+        return value
+    fernet_key = _derive_fernet_key(key)
+    f = Fernet(fernet_key)
+    return f.encrypt(value.encode()).decode()
+
+
+def decrypt_value(encrypted: str, key: str) -> str:
+    """Decrypt a value using Fernet symmetric encryption."""
+    if not key:
+        return encrypted
+    fernet_key = _derive_fernet_key(key)
+    f = Fernet(fernet_key)
+    return f.decrypt(encrypted.encode()).decode()
+
+
+def _derive_fernet_key(key: str) -> bytes:
+    """Derive a Fernet-compatible key from an arbitrary string."""
+    digest = hashlib.sha256(key.encode()).digest()
+    return urlsafe_b64encode(digest)

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -1,0 +1,48 @@
+"""Database initialization and session management."""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.database.models import Base
+from app.settings import Settings
+
+_engine = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+async def init_database(settings: Settings) -> None:
+    """Initialize the database engine and create tables."""
+    global _engine, _session_factory
+
+    _engine = create_async_engine(settings.database_url, echo=False)
+    _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
+
+    async with _engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def close_database() -> None:
+    """Close the database engine."""
+    global _engine
+    if _engine:
+        await _engine.dispose()
+        _engine = None
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """Dependency that provides a database session."""
+    if _session_factory is None:
+        raise RuntimeError("Database not initialized. Call init_database first.")
+    async with _session_factory() as session:
+        yield session
+
+
+@asynccontextmanager
+async def get_db_context() -> AsyncGenerator[AsyncSession, None]:
+    """Context manager for database sessions (for use outside FastAPI)."""
+    if _session_factory is None:
+        raise RuntimeError("Database not initialized. Call init_database first.")
+    async with _session_factory() as session:
+        yield session

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -2,6 +2,7 @@
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -15,6 +16,13 @@ _session_factory: async_sessionmaker[AsyncSession] | None = None
 async def init_database(settings: Settings) -> None:
     """Initialize the database engine and create tables."""
     global _engine, _session_factory
+
+    if settings.database_url.startswith("sqlite"):
+        db_path = settings.database_url.replace("sqlite+aiosqlite:///", "")
+        if db_path.startswith("./"):
+            db_path = db_path[2:]
+        if db_path != ":memory:":
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
     _engine = create_async_engine(settings.database_url, echo=False)
     _session_factory = async_sessionmaker(_engine, expire_on_commit=False)

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,0 +1,67 @@
+"""SQLAlchemy ORM models."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    github_id: Mapped[int] = mapped_column(Integer, unique=True, nullable=False, index=True)
+    username: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str | None] = mapped_column(String(255))
+    avatar_url: Mapped[str | None] = mapped_column(Text)
+    github_access_token_encrypted: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    tokens: Mapped[list["APIToken"]] = relationship(
+        "APIToken", back_populates="user", cascade="all, delete-orphan"
+    )
+
+
+class APIToken(Base):
+    __tablename__ = "api_tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    token_prefix: Mapped[str] = mapped_column(String(16), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    scopes: Mapped[str] = mapped_column(Text, default="")
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime)
+
+    user: Mapped["User"] = relationship("User", back_populates="tokens")
+
+    __table_args__ = (Index("idx_api_tokens_user", "user_id"),)
+
+
+class DeviceCode(Base):
+    __tablename__ = "device_codes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    device_code: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    user_code: Mapped[str] = mapped_column(String(16), unique=True, nullable=False, index=True)
+    verification_uri: Mapped[str] = mapped_column(Text, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    interval: Mapped[int] = mapped_column(Integer, default=5)
+    user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"))
+    authorized_at: Mapped[datetime | None] = mapped_column(DateTime)
+    token_name: Mapped[str] = mapped_column(String(255), default="CLI Token")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    user: Mapped["User | None"] = relationship("User")

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,9 +1,13 @@
 from typing import Annotated
 
-from fastapi import Cookie, Depends, Header, Request
+from fastapi import Cookie, Depends, Header, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_user_from_token
+from app.database import get_db
+from app.database.models import User as DBUser
 from app.models import User
+from app.services.token_service import validate_bearer_token
 from app.settings import Settings
 
 
@@ -13,8 +17,23 @@ def config(request: Request) -> Settings:
 
 async def current_user(
     config: Annotated[Settings, Depends(config)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     access_token: Annotated[str | None, Cookie()] = None,
+    authorization: Annotated[str | None, Header()] = None,
 ) -> User | None:
+    """Authenticate user via Bearer token (CLI) or cookie (web)."""
+    if authorization and authorization.startswith("Bearer "):
+        token = authorization[7:]
+        if token.startswith("lb_v1_"):
+            db_user = await validate_bearer_token(db, token)
+            if db_user:
+                return User(
+                    login=db_user.username,
+                    name=db_user.name,
+                    avatar_url=db_user.avatar_url or "",
+                )
+        return None
+
     if access_token is None:
         return None
 
@@ -22,6 +41,40 @@ async def current_user(
         return User(login="dummy")
 
     return await get_user_from_token(access_token)
+
+
+async def current_db_user(
+    config: Annotated[Settings, Depends(config)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    access_token: Annotated[str | None, Cookie()] = None,
+    authorization: Annotated[str | None, Header()] = None,
+) -> DBUser | None:
+    """Get the database user record for authenticated user."""
+    if authorization and authorization.startswith("Bearer "):
+        token = authorization[7:]
+        if token.startswith("lb_v1_"):
+            return await validate_bearer_token(db, token)
+        return None
+
+    return None
+
+
+async def require_user(
+    user: Annotated[User | None, Depends(current_user)],
+) -> User:
+    """Dependency that requires authentication."""
+    if user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user
+
+
+async def require_db_user(
+    db_user: Annotated[DBUser | None, Depends(current_db_user)],
+) -> DBUser:
+    """Dependency that requires authentication and returns DB user."""
+    if db_user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return db_user
 
 
 async def is_partial_request(

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,15 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
 import sentry_sdk
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from app import templates
+from app.database import close_database, init_database
 from app.routes import router
+from app.routes.device_auth import router as device_auth_router
+from app.routes.tokens import router as tokens_router
 from app.settings import Settings
 
 
@@ -15,14 +21,24 @@ def init_sentry(settings: Settings) -> None:
     )
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    config: Settings = app.extra["config"]
+    await init_database(config)
+    yield
+    await close_database()
+
+
 def create_app(config: Settings | None = None) -> FastAPI:
     config = config or Settings()  # type: ignore[call-arg]
 
-    app = FastAPI()
+    app = FastAPI(lifespan=lifespan)
     app.mount("/static", StaticFiles(directory=config.static_dir), name="static")
 
     templates.init_app(app, settings=config)
     app.include_router(router)
+    app.include_router(device_auth_router)
+    app.include_router(tokens_router)
 
     # Mount the config to the app so we can inject it into requests
     app.extra["config"] = config

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Route modules."""
+
+from app.routes.main import router
+
+__all__ = ["router"]

--- a/app/routes/device_auth.py
+++ b/app/routes/device_auth.py
@@ -1,0 +1,195 @@
+"""Device flow authentication endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Cookie, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_github_user_data
+from app.database import get_db
+from app.dependencies import config, current_user
+from app.models import User
+from app.services.device_flow import (
+    DeviceFlowError,
+    authorize_device_code,
+    create_device_code_record,
+    get_device_code_by_user_code,
+    poll_device_code,
+)
+from app.services.user_service import get_or_create_user
+from app.settings import Settings
+from app.templates import render_template
+
+router = APIRouter(tags=["device-auth"])
+
+
+class DeviceCodeRequest(BaseModel):
+    token_name: str = "CLI Token"
+
+
+class DeviceCodeResponse(BaseModel):
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    expires_in: int
+    interval: int
+
+
+class DeviceTokenRequest(BaseModel):
+    device_code: str
+    grant_type: str = "urn:ietf:params:oauth:grant-type:device_code"
+
+
+class DeviceTokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+
+
+class DeviceErrorResponse(BaseModel):
+    error: str
+    error_description: str
+
+
+@router.post("/auth/device/code")
+async def request_device_code(
+    request: Request,
+    body: DeviceCodeRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> DeviceCodeResponse:
+    """Initiate device flow authentication.
+
+    CLI calls this to get a user code to display.
+    """
+    verification_uri = str(request.url_for("device_authorize_page"))
+
+    record = await create_device_code_record(
+        db,
+        verification_uri=verification_uri,
+        token_name=body.token_name,
+    )
+
+    expires_in = int((record.expires_at - record.created_at).total_seconds())
+
+    return DeviceCodeResponse(
+        device_code=record.device_code,
+        user_code=record.user_code,
+        verification_uri=verification_uri,
+        verification_uri_complete=f"{verification_uri}?user_code={record.user_code}",
+        expires_in=expires_in,
+        interval=record.interval,
+    )
+
+
+@router.post("/auth/device/token")
+async def poll_device_token(
+    body: DeviceTokenRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    settings: Annotated[Settings, Depends(config)],
+) -> DeviceTokenResponse | DeviceErrorResponse:
+    """Poll for device code authorization status.
+
+    CLI calls this repeatedly until it gets a token.
+    """
+    try:
+        token, expires_in = await poll_device_code(
+            db,
+            device_code=body.device_code,
+            token_expiry_days=settings.token_default_expiry_days,
+        )
+        return DeviceTokenResponse(access_token=token, expires_in=expires_in)
+    except DeviceFlowError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": e.error, "error_description": e.description},
+        )
+
+
+@router.get("/device", name="device_authorize_page", response_model=None)
+async def device_authorize_page(
+    request: Request,
+    user: Annotated[User | None, Depends(current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    settings: Annotated[Settings, Depends(config)],
+    user_code: str | None = None,
+) -> HTMLResponse | RedirectResponse:
+    """Web page for user to enter device code."""
+    if user is None:
+        redirect_url = str(request.url)
+        login_url = str(request.url_for("auth_login")) + f"?next={redirect_url}"
+        return RedirectResponse(login_url)
+
+    error = None
+    device_code = None
+
+    if user_code:
+        device_code = await get_device_code_by_user_code(db, user_code)
+        if not device_code:
+            error = "Invalid or expired code"
+
+    return render_template(
+        "device.html",
+        request=request,
+        user=user,
+        user_code=user_code or "",
+        error=error,
+        device_code=device_code,
+    )
+
+
+@router.post("/device/authorize", response_model=None)
+async def authorize_device(
+    request: Request,
+    user: Annotated[User | None, Depends(current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    settings: Annotated[Settings, Depends(config)],
+    user_code: Annotated[str, Form()],
+    access_token: Annotated[str | None, Cookie()] = None,
+) -> HTMLResponse | RedirectResponse:
+    """Authorize a device code (user submits from web page)."""
+    if user is None or access_token is None:
+        return RedirectResponse(request.url_for("auth_login"))
+
+    device_code = await get_device_code_by_user_code(db, user_code)
+    if not device_code:
+        return render_template(
+            "device.html",
+            request=request,
+            user=user,
+            user_code=user_code,
+            error="Invalid or expired code",
+        )
+
+    if settings.dummy_auth:
+        db_user = await get_or_create_user(
+            db,
+            github_id=1,
+            username="dummy",
+            name="Dummy User",
+            avatar_url="",
+        )
+    else:
+        github_user = await get_github_user_data(access_token)
+        db_user = await get_or_create_user(
+            db,
+            github_id=github_user.id,
+            username=github_user.login,
+            name=github_user.name,
+            avatar_url=github_user.avatar_url,
+        )
+
+    success = await authorize_device_code(db, user_code, db_user.id)
+
+    if success:
+        return render_template("device_success.html", request=request, user=user)
+    else:
+        return render_template(
+            "device.html",
+            request=request,
+            user=user,
+            user_code=user_code,
+            error="Failed to authorize. Code may have expired.",
+        )

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -3,12 +3,15 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db
-from app.auth import exchange_code_for_token
+from app.auth import exchange_code_for_token, get_github_user_data
 from app.components import Homepage
+from app.database import get_db
 from app.dependencies import config, current_user, is_partial_request
 from app.models import User
+from app.services.user_service import get_or_create_user
 from app.settings import Settings
 from app.templates import render_template
 
@@ -73,11 +76,24 @@ async def auth_callback(
     request: Request,
     code: Annotated[str, Query],
     config: Annotated[Settings, Depends(config)],
+    db_session: Annotated[AsyncSession, Depends(get_db)],
 ) -> RedirectResponse:
     response = RedirectResponse(request.url_for("home"))
 
     if access_token := await exchange_code_for_token(code, config):
         response.set_cookie(key="access_token", value=access_token)
+
+        if not config.dummy_auth:
+            github_user = await get_github_user_data(access_token)
+            await get_or_create_user(
+                db_session,
+                github_id=github_user.id,
+                username=github_user.login,
+                name=github_user.name,
+                avatar_url=github_user.avatar_url,
+                github_access_token=access_token,
+                encryption_key=config.token_encryption_key,
+            )
 
     return response
 

--- a/app/routes/tokens.py
+++ b/app/routes/tokens.py
@@ -1,0 +1,96 @@
+"""Token management API endpoints."""
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.database.models import User as DBUser
+from app.dependencies import require_db_user
+from app.services.token_service import create_token, list_user_tokens, revoke_token
+
+router = APIRouter(prefix="/api/tokens", tags=["tokens"])
+
+
+class TokenInfo(BaseModel):
+    id: int
+    name: str
+    prefix: str
+    created_at: datetime
+    expires_at: datetime | None
+    last_used_at: datetime | None
+
+
+class TokenListResponse(BaseModel):
+    tokens: list[TokenInfo]
+
+
+class CreateTokenRequest(BaseModel):
+    name: str
+    expires_in_days: int | None = 90
+
+
+class CreateTokenResponse(BaseModel):
+    token: str
+    id: int
+    name: str
+    expires_at: datetime | None
+
+
+@router.get("")
+async def list_tokens(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[DBUser, Depends(require_db_user)],
+) -> TokenListResponse:
+    """List all API tokens for the authenticated user."""
+    tokens = await list_user_tokens(db, user.id)
+    return TokenListResponse(
+        tokens=[
+            TokenInfo(
+                id=t.id,
+                name=t.name,
+                prefix=t.token_prefix,
+                created_at=t.created_at,
+                expires_at=t.expires_at,
+                last_used_at=t.last_used_at,
+            )
+            for t in tokens
+        ]
+    )
+
+
+@router.post("")
+async def create_new_token(
+    body: CreateTokenRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[DBUser, Depends(require_db_user)],
+) -> CreateTokenResponse:
+    """Create a new API token."""
+    token, api_token = await create_token(
+        db,
+        user_id=user.id,
+        name=body.name,
+        expires_days=body.expires_in_days,
+    )
+    return CreateTokenResponse(
+        token=token,
+        id=api_token.id,
+        name=api_token.name,
+        expires_at=api_token.expires_at,
+    )
+
+
+@router.delete("/{token_id}")
+async def delete_token(
+    token_id: int,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[DBUser, Depends(require_db_user)],
+) -> dict[str, str]:
+    """Revoke an API token."""
+    success = await revoke_token(db, user.id, token_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Token not found")
+    return {"status": "ok"}

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for business logic."""

--- a/app/services/device_flow.py
+++ b/app/services/device_flow.py
@@ -1,0 +1,148 @@
+"""Device flow service for CLI authentication."""
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crypto import generate_device_code, generate_user_code
+from app.database.models import DeviceCode
+from app.services.token_service import create_token
+
+DEVICE_CODE_EXPIRY_MINUTES = 15
+DEFAULT_POLL_INTERVAL = 5
+
+
+class DeviceFlowError(Exception):
+    """Base class for device flow errors."""
+
+    error: str
+    description: str
+
+    def __init__(self, error: str, description: str):
+        self.error = error
+        self.description = description
+        super().__init__(description)
+
+
+class AuthorizationPending(DeviceFlowError):
+    def __init__(self) -> None:
+        super().__init__("authorization_pending", "User has not yet authorized")
+
+
+class SlowDown(DeviceFlowError):
+    def __init__(self) -> None:
+        super().__init__("slow_down", "Polling too fast")
+
+
+class ExpiredToken(DeviceFlowError):
+    def __init__(self) -> None:
+        super().__init__("expired_token", "Device code has expired")
+
+
+class AccessDenied(DeviceFlowError):
+    def __init__(self) -> None:
+        super().__init__("access_denied", "User denied authorization")
+
+
+async def create_device_code_record(
+    db: AsyncSession,
+    verification_uri: str,
+    token_name: str = "CLI Token",
+) -> DeviceCode:
+    """Create a new device code for CLI authentication."""
+    device_code = generate_device_code()
+    user_code = generate_user_code()
+    expires_at = datetime.utcnow() + timedelta(minutes=DEVICE_CODE_EXPIRY_MINUTES)
+
+    record = DeviceCode(
+        device_code=device_code,
+        user_code=user_code,
+        verification_uri=verification_uri,
+        expires_at=expires_at,
+        interval=DEFAULT_POLL_INTERVAL,
+        token_name=token_name,
+    )
+    db.add(record)
+    await db.commit()
+    await db.refresh(record)
+    return record
+
+
+async def get_device_code_by_user_code(db: AsyncSession, user_code: str) -> DeviceCode | None:
+    """Get a device code record by its user-facing code."""
+    user_code = user_code.upper().strip()
+    result = await db.execute(
+        select(DeviceCode)
+        .where(DeviceCode.user_code == user_code)
+        .where(DeviceCode.expires_at > datetime.utcnow())
+        .where(DeviceCode.authorized_at.is_(None))
+    )
+    return result.scalar_one_or_none()
+
+
+async def authorize_device_code(db: AsyncSession, user_code: str, user_id: int) -> bool:
+    """Mark a device code as authorized by a user."""
+    record = await get_device_code_by_user_code(db, user_code)
+    if not record:
+        return False
+
+    record.user_id = user_id
+    record.authorized_at = datetime.utcnow()
+    await db.commit()
+    return True
+
+
+async def poll_device_code(
+    db: AsyncSession,
+    device_code: str,
+    token_expiry_days: int | None = 90,
+) -> tuple[str, int]:
+    """Poll for device code status.
+
+    Returns:
+        Tuple of (token, expires_in_seconds) if authorized.
+
+    Raises:
+        AuthorizationPending: User hasn't authorized yet
+        ExpiredToken: Device code has expired
+    """
+    result = await db.execute(select(DeviceCode).where(DeviceCode.device_code == device_code))
+    record = result.scalar_one_or_none()
+
+    if not record:
+        raise ExpiredToken()
+
+    if record.expires_at < datetime.utcnow():
+        await db.delete(record)
+        await db.commit()
+        raise ExpiredToken()
+
+    if not record.authorized_at or not record.user_id:
+        raise AuthorizationPending()
+
+    token, api_token = await create_token(
+        db,
+        user_id=record.user_id,
+        name=record.token_name,
+        expires_days=token_expiry_days,
+    )
+
+    await db.delete(record)
+    await db.commit()
+
+    expires_in = 0
+    if api_token.expires_at:
+        expires_in = int((api_token.expires_at - datetime.utcnow()).total_seconds())
+
+    return token, expires_in
+
+
+async def cleanup_expired_codes(db: AsyncSession) -> int:
+    """Remove expired device codes. Returns count of deleted records."""
+    result = await db.execute(select(DeviceCode).where(DeviceCode.expires_at < datetime.utcnow()))
+    expired = list(result.scalars().all())
+    for record in expired:
+        await db.delete(record)
+    await db.commit()
+    return len(expired)

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -1,0 +1,98 @@
+"""Token service for managing API tokens."""
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crypto import generate_api_token, get_token_prefix, hash_token
+from app.database.models import APIToken, User
+
+
+async def create_token(
+    db: AsyncSession,
+    user_id: int,
+    name: str,
+    expires_days: int | None = 90,
+) -> tuple[str, APIToken]:
+    """Create a new API token for a user.
+
+    Returns:
+        Tuple of (full_token, token_record). The full_token is only returned once
+        and should be shown to the user immediately.
+    """
+    token, token_hash = generate_api_token()
+    prefix = get_token_prefix(token)
+
+    expires_at = None
+    if expires_days is not None:
+        expires_at = datetime.utcnow() + timedelta(days=expires_days)
+
+    api_token = APIToken(
+        user_id=user_id,
+        token_hash=token_hash,
+        token_prefix=prefix,
+        name=name,
+        expires_at=expires_at,
+    )
+    db.add(api_token)
+    await db.commit()
+    await db.refresh(api_token)
+
+    return token, api_token
+
+
+async def validate_bearer_token(db: AsyncSession, token: str) -> User | None:
+    """Validate a bearer token and return the associated user.
+
+    Also updates last_used_at timestamp.
+    """
+    token_hash = hash_token(token)
+
+    result = await db.execute(
+        select(APIToken)
+        .where(APIToken.token_hash == token_hash)
+        .where(APIToken.revoked_at.is_(None))
+    )
+    api_token = result.scalar_one_or_none()
+
+    if not api_token:
+        return None
+
+    if api_token.expires_at and api_token.expires_at < datetime.utcnow():
+        return None
+
+    api_token.last_used_at = datetime.utcnow()
+    await db.commit()
+
+    user_result = await db.execute(select(User).where(User.id == api_token.user_id))
+    return user_result.scalar_one_or_none()
+
+
+async def list_user_tokens(db: AsyncSession, user_id: int) -> list[APIToken]:
+    """List all non-revoked tokens for a user."""
+    result = await db.execute(
+        select(APIToken)
+        .where(APIToken.user_id == user_id)
+        .where(APIToken.revoked_at.is_(None))
+        .order_by(APIToken.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def revoke_token(db: AsyncSession, user_id: int, token_id: int) -> bool:
+    """Revoke a token. Returns True if token was found and revoked."""
+    result = await db.execute(
+        select(APIToken)
+        .where(APIToken.id == token_id)
+        .where(APIToken.user_id == user_id)
+        .where(APIToken.revoked_at.is_(None))
+    )
+    api_token = result.scalar_one_or_none()
+
+    if not api_token:
+        return False
+
+    api_token.revoked_at = datetime.utcnow()
+    await db.commit()
+    return True

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,0 +1,59 @@
+"""User service for managing user records."""
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crypto import encrypt_value
+from app.database.models import User
+
+
+async def get_or_create_user(
+    db: AsyncSession,
+    github_id: int,
+    username: str,
+    name: str | None,
+    avatar_url: str | None,
+    github_access_token: str | None = None,
+    encryption_key: str = "",
+) -> User:
+    """Get an existing user by GitHub ID or create a new one."""
+    result = await db.execute(select(User).where(User.github_id == github_id))
+    user = result.scalar_one_or_none()
+
+    if user:
+        user.username = username
+        user.name = name
+        user.avatar_url = avatar_url
+        user.updated_at = datetime.utcnow()
+        if github_access_token:
+            user.github_access_token_encrypted = encrypt_value(github_access_token, encryption_key)
+        await db.commit()
+        return user
+
+    user = User(
+        github_id=github_id,
+        username=username,
+        name=name,
+        avatar_url=avatar_url,
+        github_access_token_encrypted=(
+            encrypt_value(github_access_token, encryption_key) if github_access_token else None
+        ),
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
+    """Get a user by their database ID."""
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def get_user_by_github_id(db: AsyncSession, github_id: int) -> User | None:
+    """Get a user by their GitHub ID."""
+    result = await db.execute(select(User).where(User.github_id == github_id))
+    return result.scalar_one_or_none()

--- a/app/settings.py
+++ b/app/settings.py
@@ -11,6 +11,10 @@ class Settings(BaseSettings):
     live_reload_mode: bool = False
     dummy_auth: bool = False
 
+    database_url: str = "sqlite+aiosqlite:///./lembas.db"
+    token_default_expiry_days: int = 90
+    token_encryption_key: str = ""
+
     client_id: str
     client_secret: str
     redirect_url: str = "http://lembas.localhost"

--- a/app/settings.py
+++ b/app/settings.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     live_reload_mode: bool = False
     dummy_auth: bool = False
 
-    database_url: str = "sqlite+aiosqlite:///./lembas.db"
+    database_url: str = "sqlite+aiosqlite:///./data/lembas.db"
     token_default_expiry_days: int = 90
     token_encryption_key: str = ""
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,16 +1,7 @@
 version: 7
 platforms:
 - name: linux-64
-  virtual-packages:
-  - __unix=0=0
-  - __linux=4.18
-  - __glibc=2.28
-  - __archspec=0=x86_64
 - name: osx-arm64
-  virtual-packages:
-  - __unix=0=0
-  - __osx=13.0
-  - __archspec=0=m1
 environments:
   default:
     channels:
@@ -24,7 +15,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py314h4a8dc5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-50.0.0-py314h7fe84b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fastar-0.11.0-py314h0b738fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.4-py314h42812f9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py314h5bd0f2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
@@ -50,6 +43,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.0-h462bb3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py314h5bd0f2a_1.conda
@@ -58,6 +52,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosqlite-0.22.1-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
@@ -134,6 +129,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8c/7f/eab7def87914f272500236e3d765649c64a7bc83e24cf1b8303f76bfc6cf/jinja_partials-0.3.2-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosqlite-0.22.1-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.2-pyhcf101f3_0.conda
@@ -211,7 +207,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.0-py314h7bede21_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-50.0.0-py314h0d331bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastar-0.11.0-py314hbcbdb20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.5.4-py314he609de1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/httptools-0.8.0-py314h6c2aa35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hc7cc350_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
@@ -233,6 +231,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.16.0-h828de30_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.51-py314ha14b1ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.1.0-py314h6cfcd04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvloop-0.22.1-py314h0612a62_1.conda
@@ -327,6 +326,25 @@ packages:
   run_exports: {}
   size: 306297
   timestamp: 1783424159025
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-50.0.0-py314h7fe84b3_0.conda
+  sha256: fd903503d8e7ab2c70ce839f05a80ecd67bcda710a2490179e7280b4e2943ca4
+  md5: 557e2f330a5015e0e79185c30bd7e5ad
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=2.0
+  - libgcc >=14
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=compressed-mapping
+  run_exports: {}
+  size: 1914834
+  timestamp: 1785640778304
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fastar-0.11.0-py314h0b738fb_0.conda
   sha256: 2d73e265b8b105a0b9f3eaf024c4564d39b3ac2a973c6c9a94ee3c0aa6777b85
   md5: 71e6f16831c3276a80373ba89f11a327
@@ -345,6 +363,22 @@ packages:
   run_exports: {}
   size: 423416
   timestamp: 1776177826024
+- conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.4-py314h42812f9_0.conda
+  sha256: 9e3c3711e4e84368a5cd07326a42d13b8f25a8d81a4436e58cbf18115f9960f5
+  md5: feec8f5a0aa58e94c8eeb53ad73ed805
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/greenlet?source=hash-mapping
+  run_exports: {}
+  size: 277466
+  timestamp: 1784885441255
 - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py314h5bd0f2a_1.conda
   sha256: 91bfdf1dad0fa57efc2404ca00f5fee8745ad9b56ec1d0df298fd2882ad39806
   md5: 067a52c66f453b97771650bbb131e2b5
@@ -739,6 +773,23 @@ packages:
   run_exports: {}
   size: 9384917
   timestamp: 1784938279462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
+  sha256: 3c46e9af535a376c7269b61563f84c601235b00d50fc97f87ffbf3b68a51fe17
+  md5: aeb7447f3ea37b2bb32167267dcf0bfe
+  depends:
+  - python
+  - greenlet !=0.4.17
+  - typing-extensions >=4.6.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/sqlalchemy?source=hash-mapping
+  run_exports: {}
+  size: 4034632
+  timestamp: 1781547880247
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
   build_number: 103
   sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
@@ -861,6 +912,19 @@ packages:
   run_exports: {}
   size: 8144
   timestamp: 1784221492234
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosqlite-0.22.1-pyhcf101f3_1.conda
+  sha256: 8b23dfe615f958724269733d348139fb7615f29e0d35a9b556fe823d65a941a8
+  md5: 9be31ce1f8e613fbb3b140430e109d41
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/aiosqlite?source=hash-mapping
+  run_exports: {}
+  size: 22318
+  timestamp: 1767730199932
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
   sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
   md5: 52be5139047efadaeeb19c6a5103f92a
@@ -1964,6 +2028,24 @@ packages:
   run_exports: {}
   size: 297959
   timestamp: 1783425112331
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-50.0.0-py314h0d331bb_0.conda
+  sha256: 3ed0b771e5defffbf15a76b1215ca7a4f2d3cbacb6e0e65c79022e6471806508
+  md5: fa6e390bc78aa838d78215c5dd4282a0
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1841582
+  timestamp: 1785640795979
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fastar-0.11.0-py314hbcbdb20_0.conda
   sha256: 39e1a0e2f73851bdf5cbda4acf81275f523d8eb46b2636ce02d89c9fd0e18701
   md5: 37067a410589437e9e62d95f2b28196b
@@ -1981,6 +2063,22 @@ packages:
   run_exports: {}
   size: 380351
   timestamp: 1776177849422
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.5.4-py314he609de1_0.conda
+  sha256: 902deb016bb78e39f38eeaad4eff9de8a6f79f41d29d40e00b986de13a2fae9e
+  md5: 0a2824f370a6ae57256bb12f7c17be85
+  depends:
+  - python
+  - python 3.14.* *_cp314
+  - __osx >=11.0
+  - libcxx >=19
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/greenlet?source=hash-mapping
+  run_exports: {}
+  size: 273467
+  timestamp: 1784885632350
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/httptools-0.8.0-py314h6c2aa35_0.conda
   sha256: 1a8d246a4dd22e16b5c37d8d5f3efaf8d2dd566629c790c29cf8e2a5d89c5208
   md5: 930eb3505f8de78940ef851f388943f4
@@ -2300,6 +2398,23 @@ packages:
   run_exports: {}
   size: 8617591
   timestamp: 1784938415804
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.51-py314ha14b1ff_0.conda
+  sha256: c355708c29086c3ce0916f5d5367cfea733f73d9c194b4fa5d21a40317374d32
+  md5: 540fe3cb235eb16dcf0ff5e13eb96411
+  depends:
+  - python
+  - greenlet !=0.4.17
+  - typing-extensions >=4.6.0
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/sqlalchemy?source=hash-mapping
+  run_exports: {}
+  size: 4036851
+  timestamp: 1781547978515
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
   sha256: 47186bc7ab8d7e8bee86bbd1a917196f8c21cf63f081fc33cd6d1221af087580
   md5: 8e3cf0e455e6b54519f0b1c72c61780a

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,6 @@
 [dependencies]
+aiosqlite = "*"
+cryptography = "*"
 fastapi = "*"
 httpx = "*"
 jinja2 = "*"
@@ -6,6 +8,7 @@ pydantic = "*"
 pydantic-settings = "*"
 python = ">=3.12"
 sentry-sdk = "*"
+sqlalchemy = ">=2.0"
 uvicorn = "*"
 
 [environments]

--- a/templates/device.html
+++ b/templates/device.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Authorize Device - Lembas</title>
+    <link rel="icon" href="/static/images/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="/static/css/output.css" />
+  </head>
+  <body class="bg-gray-100 min-h-screen flex items-center justify-center">
+    <div class="bg-white p-8 rounded-lg shadow-md max-w-md w-full">
+      <div class="text-center mb-6">
+        <img
+          src="/static/images/logo.svg"
+          alt="Lembas"
+          class="h-12 mx-auto mb-4"
+        />
+        <h1 class="text-2xl font-bold text-gray-800">Authorize Device</h1>
+        <p class="text-gray-600 mt-2">
+          Enter the code displayed in your CLI to authorize this device.
+        </p>
+      </div>
+
+      {% if error %}
+      <div
+        class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4"
+      >
+        {{ error }}
+      </div>
+      {% endif %} {% if device_code %}
+      <div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
+        <p class="text-gray-700 mb-2">You are about to authorize:</p>
+        <p class="font-mono text-lg text-center bg-white p-2 rounded border">
+          {{ device_code.token_name }}
+        </p>
+      </div>
+      <form action="/device/authorize" method="POST">
+        <input type="hidden" name="user_code" value="{{ user_code }}" />
+        <button
+          type="submit"
+          class="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-4 rounded-lg transition duration-200"
+        >
+          Authorize Device
+        </button>
+      </form>
+      {% else %}
+      <form action="/device" method="GET">
+        <div class="mb-4">
+          <label for="user_code" class="block text-gray-700 font-medium mb-2">
+            Device Code
+          </label>
+          <input
+            type="text"
+            id="user_code"
+            name="user_code"
+            value="{{ user_code }}"
+            placeholder="LMBS-XXXX"
+            class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-lg text-center uppercase"
+            maxlength="9"
+            autocomplete="off"
+            autofocus
+          />
+        </div>
+        <button
+          type="submit"
+          class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-lg transition duration-200"
+        >
+          Continue
+        </button>
+      </form>
+      {% endif %}
+
+      <p class="text-center text-gray-500 text-sm mt-6">
+        Logged in as <span class="font-medium">{{ user.username }}</span>
+      </p>
+    </div>
+  </body>
+</html>

--- a/templates/device_success.html
+++ b/templates/device_success.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Device Authorized - Lembas</title>
+    <link rel="icon" href="/static/images/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="/static/css/output.css" />
+  </head>
+  <body class="bg-gray-100 min-h-screen flex items-center justify-center">
+    <div class="bg-white p-8 rounded-lg shadow-md max-w-md w-full text-center">
+      <div class="mb-6">
+        <img
+          src="/static/images/logo.svg"
+          alt="Lembas"
+          class="h-12 mx-auto mb-4"
+        />
+        <div
+          class="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4"
+        >
+          <svg
+            class="w-8 h-8 text-green-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M5 13l4 4L19 7"
+            ></path>
+          </svg>
+        </div>
+        <h1 class="text-2xl font-bold text-gray-800">Device Authorized</h1>
+        <p class="text-gray-600 mt-2">
+          You can now close this window and return to your CLI.
+        </p>
+      </div>
+
+      <p class="text-gray-500 text-sm">
+        Your CLI should receive the authentication token momentarily.
+      </p>
+
+      <a href="/" class="inline-block mt-6 text-blue-600 hover:text-blue-800">
+        Go to dashboard
+      </a>
+    </div>
+  </body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
+from app.database import close_database, init_database
 from app.main import create_app
 from app.settings import Settings
 
@@ -11,12 +12,16 @@ ClientFactory = Callable[[], httpx.AsyncClient]
 
 
 @pytest.fixture(scope="session")
-def app() -> FastAPI:
+async def app() -> AsyncIterator[FastAPI]:
     config = Settings(
         client_id="test-client-id",
         client_secret="test-client-secret",
+        database_url="sqlite+aiosqlite:///:memory:",
     )
-    return create_app(config=config)
+    app = create_app(config=config)
+    await init_database(config)
+    yield app
+    await close_database()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,9 @@ async def test_get_health(client: AsyncClient) -> None:
 
 
 async def test_auth_callback_success(client: AsyncClient, mocker: Mock, base_url: str) -> None:
-    mock = mocker.patch("app.routes.exchange_code_for_token", return_value="valid-access-token")
+    mock = mocker.patch(
+        "app.routes.main.exchange_code_for_token", return_value="valid-access-token"
+    )
 
     response = await client.get(
         "/auth/callback", params={"code": "valid-code"}, follow_redirects=False
@@ -28,7 +30,7 @@ async def test_auth_callback_success(client: AsyncClient, mocker: Mock, base_url
 async def test_auth_callback_redirect_on_failure(
     client: AsyncClient, mocker: Mock, base_url: str
 ) -> None:
-    mock = mocker.patch("app.routes.exchange_code_for_token", return_value=None)
+    mock = mocker.patch("app.routes.main.exchange_code_for_token", return_value=None)
 
     response = await client.get(
         "/auth/callback", params={"code": "bad-code"}, follow_redirects=False


### PR DESCRIPTION
## Summary

Implements OAuth device flow for CLI authentication with long-lived API tokens prefixed `lb_v1_`.

- Add SQLite database with SQLAlchemy async ORM (User, APIToken, DeviceCode models)
- Add device flow endpoints: `POST /auth/device/code`, `POST /auth/device/token`
- Add web pages for device authorization (`/device`, `/device/authorize`)
- Add token management API: `GET/POST/DELETE /api/tokens`
- Support dual authentication: Bearer tokens (CLI) and cookies (web)
- Persist GitHub users to database on OAuth callback

## Device Flow Sequence

1. CLI calls `POST /auth/device/code` → gets `user_code` to display
2. User visits `/device`, logs in via GitHub OAuth if needed, enters code
3. CLI polls `POST /auth/device/token` until authorized
4. Server generates `lb_v1_...` token, returns it
5. CLI stores token in keychain

## Test plan

- [x] Tests pass (`pixi run test`)
- [ ] Manual test: start server, request device code via curl, visit `/device` in browser, authorize, poll for token
- [ ] Verify token works with `Authorization: Bearer lb_v1_...` header