### PR TITLE
chore: Add large directories to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,13 @@
 .git/
 .gitignore
 .idea/
-.ruff_cache/
+.mypy_cache/
+.pixi/
 .pytest_cache/
+.ruff_cache/
+/data/
 /envs/
 __pycache__/
+infra/
+node_modules/
+tests/


### PR DESCRIPTION
Reduces Docker build context from ~436MB to ~2MB by excluding .pixi/, .mypy_cache/, node_modules/, and tests/.