### PR TITLE
ci(deploy): Add workflow_dispatch trigger for manual deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 jobs:
   deploy:
     name: Deploy app to fly.io


### PR DESCRIPTION
Allows manually triggering deploys from GitHub Actions UI.