### PR TITLE
fix(deploy): Run migrations at app startup instead of release_command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=builder /app/.pixi /app/.pixi
 COPY app/ ./app/
 COPY migrations/ ./migrations/
 COPY alembic.ini ./
+COPY entrypoint.sh ./
 
 # Set environment to use pixi's Python
 ENV PATH="/app/.pixi/envs/default/bin:${PATH}"
@@ -35,4 +36,5 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 EXPOSE 8000
 
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Run database migrations
+alembic upgrade head
+
+# Start the application
+exec "$@"

--- a/fly.toml
+++ b/fly.toml
@@ -3,9 +3,6 @@ primary_region = "dfw"
 
 [build]
 
-[deploy]
-release_command = "alembic upgrade head"
-
 [env]
 CLIENT_ID = "Ov23liZQ3GSRQrONST3V"
 DATABASE_URL = "sqlite+aiosqlite:///data/lembas.db"


### PR DESCRIPTION
The release_command runs on a separate machine without the volume attached, so migrations weren't applied to the persistent database. Now migrations run at app startup in the lifespan handler.