### PR TITLE
chore(ruff): Enforce force-single-line imports

### DIFF
--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -4,12 +4,10 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from sqlalchemy.ext.asyncio import (
-    AsyncEngine,
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from app.database.models import Base as Base
 from app.settings import Settings

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,11 +1,18 @@
 """SQLAlchemy ORM models."""
 
-from datetime import UTC, datetime
+from datetime import UTC
+from datetime import datetime
 from typing import Any
 
-from sqlalchemy import DateTime, Integer, String, Text, TypeDecorator
+from sqlalchemy import DateTime
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy import Text
+from sqlalchemy import TypeDecorator
 from sqlalchemy.engine import Dialect
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
 
 
 class TZDateTime(TypeDecorator[datetime]):

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,6 +1,8 @@
 from typing import Annotated
 
-from fastapi import Cookie, Depends, Request
+from fastapi import Cookie
+from fastapi import Depends
+from fastapi import Request
 
 from app.auth import get_user_from_token
 from app.schemas import User

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,8 @@ from contextlib import asynccontextmanager
 import sentry_sdk
 from fastapi import FastAPI
 
-from app.database import close_database, init_database
+from app.database import close_database
+from app.database import init_database
 from app.routes import router
 from app.settings import Settings
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,13 +1,19 @@
 import logging
-from typing import Annotated, Any
+from typing import Annotated
+from typing import Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Query
+from fastapi import Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import exchange_code_for_token, get_github_user_data
+from app.auth import exchange_code_for_token
+from app.auth import get_github_user_data
 from app.database import get_db
-from app.dependencies import config, current_user
+from app.dependencies import config
+from app.dependencies import current_user
 from app.schemas import User
 from app.services.user_service import get_or_create_user
 from app.settings import Settings

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,7 +2,8 @@
 
 from urllib.parse import urlencode
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings
+from pydantic_settings import SettingsConfigDict
 
 
 class Settings(BaseSettings):

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -3,7 +3,8 @@ from logging.config import fileConfig
 from pathlib import Path
 
 from alembic import context
-from sqlalchemy import create_engine, pool
+from sqlalchemy import create_engine
+from sqlalchemy import pool
 
 from app.database.models import Base
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ target-version = "py312"
 fixable = ["ALL"]
 # see https://docs.astral.sh/ruff/rules/
 select = ["F", "E", "W", "C90", "I", "UP"]
+
+[tool.ruff.lint.isort]
+force-single-line = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
+from collections.abc import Callable
 
 import httpx
 import pytest
 from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import close_database, get_db_context, get_engine, init_database
+from app.database import close_database
+from app.database import get_db_context
+from app.database import get_engine
+from app.database import init_database
 from app.database.models import Base
 from app.main import create_app
 from app.settings import Settings

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 from httpx import AsyncClient
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,13 +1,19 @@
 """Tests for database utilities and types."""
 
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 
 import pytest
-from sqlalchemy import Integer, select
+from sqlalchemy import Integer
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
 
-from app.database.models import Base, TZDateTime
+from app.database.models import Base
+from app.database.models import TZDateTime
 
 
 class TimestampModel(Base):

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -2,11 +2,9 @@ from datetime import UTC
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.services.user_service import (
-    get_or_create_user,
-    get_user_by_github_id,
-    get_user_by_id,
-)
+from app.services.user_service import get_or_create_user
+from app.services.user_service import get_user_by_github_id
+from app.services.user_service import get_user_by_id
 
 
 async def test_create_new_user(db: AsyncSession) -> None:


### PR DESCRIPTION
Adds `force-single-line = true` to `[tool.ruff.lint.isort]` and applies the resulting reformatting across all source and test files.

No logic changes — import style only.