### PR TITLE
chore(db): Use UUID primary keys for all models, composite PK for Case

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3,19 +3,21 @@
 from datetime import UTC
 from datetime import datetime
 from typing import Any
+from uuid import uuid4
 
 from sqlalchemy import DateTime
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
-from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy import TypeDecorator
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.engine import Dialect
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import relationship
+from sqlalchemy.types import Uuid
 
 
 class TZDateTime(TypeDecorator[datetime]):
@@ -39,6 +41,10 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
+def _new_uuid() -> str:
+    return str(uuid4())
+
+
 class Base(DeclarativeBase):
     pass
 
@@ -46,8 +52,8 @@ class Base(DeclarativeBase):
 class User(Base):
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    github_id: Mapped[int] = mapped_column(Integer, unique=True, nullable=False, index=True)
+    id: Mapped[str] = mapped_column(Uuid(as_uuid=False), primary_key=True, default=_new_uuid)
+    github_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     username: Mapped[str] = mapped_column(String(255), nullable=False)
     avatar_url: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(TZDateTime, default=_utc_now)
@@ -59,7 +65,7 @@ class Study(Base):
 
     __tablename__ = "studies"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid(as_uuid=False), primary_key=True, default=_new_uuid)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     tags: Mapped[str | None] = mapped_column(Text)  # JSON array
@@ -77,12 +83,12 @@ class Case(Base):
     """A single case execution within a study."""
 
     __tablename__ = "cases"
+    __table_args__ = (UniqueConstraint("study_id", "case_id"),)
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     study_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("studies.id"), nullable=False, index=True
+        Uuid(as_uuid=False), ForeignKey("studies.id"), nullable=False, primary_key=True
     )
-    case_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    case_id: Mapped[str] = mapped_column(String(64), nullable=False, primary_key=True)
     handler_fqn: Mapped[str] = mapped_column(Text, nullable=False)
     inputs: Mapped[str | None] = mapped_column(Text)  # JSON dict
     status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import DateTime
+from sqlalchemy import Float
+from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
@@ -13,6 +15,7 @@ from sqlalchemy.engine import Dialect
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import relationship
 
 
 class TZDateTime(TypeDecorator[datetime]):
@@ -49,3 +52,45 @@ class User(Base):
     avatar_url: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(TZDateTime, default=_utc_now)
     updated_at: Mapped[datetime] = mapped_column(TZDateTime, default=_utc_now, onupdate=_utc_now)
+
+
+class Study(Base):
+    """A named collection of case runs."""
+
+    __tablename__ = "studies"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    tags: Mapped[str | None] = mapped_column(Text)  # JSON array
+    plugins_declared: Mapped[str | None] = mapped_column(Text)  # JSON array
+    handlers: Mapped[str | None] = mapped_column(Text)  # JSON dict keyed by fingerprint
+    created_at: Mapped[datetime] = mapped_column(TZDateTime, default=_utc_now)
+    pushed_by: Mapped[str | None] = mapped_column(String(255))
+
+    cases: Mapped[list["Case"]] = relationship(
+        "Case", back_populates="study", cascade="all, delete-orphan"
+    )
+
+
+class Case(Base):
+    """A single case execution within a study."""
+
+    __tablename__ = "cases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    study_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("studies.id"), nullable=False, index=True
+    )
+    case_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    handler_fqn: Mapped[str] = mapped_column(Text, nullable=False)
+    inputs: Mapped[str | None] = mapped_column(Text)  # JSON dict
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    started_at: Mapped[datetime | None] = mapped_column(TZDateTime)
+    completed_at: Mapped[datetime | None] = mapped_column(TZDateTime)
+    duration_seconds: Mapped[float | None] = mapped_column(Float)
+    results: Mapped[str | None] = mapped_column(Text)  # JSON dict
+    error_message: Mapped[str | None] = mapped_column(Text)
+    environment: Mapped[str | None] = mapped_column(Text)  # JSON dict
+
+    study: Mapped["Study"] = relationship("Study", back_populates="cases")

--- a/app/routes.py
+++ b/app/routes.py
@@ -171,4 +171,3 @@ async def update_case_status(
         raise HTTPException(status_code=404, detail="Study or case not found")
     log.info(f"Updated case {case_id} in study {study_id} to {update.status}")
     return {"status": "ok", "case": case}
-

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,8 +4,10 @@ from typing import Any
 
 from fastapi import APIRouter
 from fastapi import Depends
+from fastapi import HTTPException
 from fastapi import Query
 from fastapi import Request
+from fastapi import status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,7 +16,12 @@ from app.auth import get_github_user_data
 from app.database import get_db
 from app.dependencies import config
 from app.dependencies import current_user
+from app.schemas import CaseStatusUpdate
+from app.schemas import Study
+from app.schemas import StudyCreate
+from app.schemas import StudyResponse
 from app.schemas import User
+from app.services import study_service
 from app.services.user_service import get_or_create_user
 from app.settings import Settings
 
@@ -83,3 +90,85 @@ async def auth_logout(request: Request) -> RedirectResponse:
     response = RedirectResponse(request.url_for("home"))
     response.delete_cookie(key="access_token")
     return response
+
+
+# --- Study API Endpoints ---
+
+
+@router.post("/api/studies", status_code=status.HTTP_201_CREATED)
+async def create_study(
+    payload: StudyCreate,
+    user: Annotated[User | None, Depends(current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Study:
+    """Register a new study with its cases."""
+    pushed_by = user.username if user else None
+    study = await study_service.create_study(db, payload, pushed_by=pushed_by)
+    log.info(f"Created study {study.id} with {len(study.cases)} cases")
+    return study
+
+
+@router.get("/api/studies/{study_id}")
+async def get_study(
+    study_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Study:
+    """Fetch a study by ID (raw format)."""
+    study = await study_service.get_study(db, study_id)
+    if not study:
+        raise HTTPException(status_code=404, detail="Study not found")
+    return study
+
+
+@router.put("/api/studies/{study_id}")
+async def update_study(
+    study_id: str,
+    payload: StudyCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Study:
+    """Update an existing study, upserting cases."""
+    study = await study_service.update_study(db, study_id, payload)
+    if not study:
+        raise HTTPException(status_code=404, detail="Study not found")
+    log.info(f"Updated study {study.id} with {len(study.cases)} cases")
+    return study
+
+
+@router.delete("/api/studies/{study_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_study(
+    study_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Delete a study and all its cases."""
+    deleted = await study_service.delete_study(db, study_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Study not found")
+    log.info(f"Deleted study {study_id}")
+
+
+@router.get("/api/studies/{study_id}/detail")
+async def get_study_detail(
+    study_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> StudyResponse:
+    """Fetch a study in UI-friendly format."""
+    study = await study_service.get_study(db, study_id)
+    if not study:
+        raise HTTPException(status_code=404, detail="Study not found")
+    return StudyResponse.from_study(study)
+
+
+@router.patch("/api/studies/{study_id}/cases/{case_id}")
+async def update_case_status(
+    study_id: str,
+    case_id: str,
+    update: CaseStatusUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Update the status of a case within a study."""
+    case = await study_service.update_case_status(db, study_id, case_id, update)
+    if not case:
+        raise HTTPException(status_code=404, detail="Study or case not found")
+    log.info(f"Updated case {case_id} in study {study_id} to {update.status}")
+    return {"status": "ok", "case": case}
+

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,8 @@
-from pydantic import BaseModel
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class User(BaseModel):
@@ -6,3 +10,117 @@ class User(BaseModel):
 
     username: str
     avatar_url: str = ""
+
+
+class CaseStatus(StrEnum):
+    pending = "pending"
+    running = "running"
+    complete = "complete"
+    failed = "failed"
+
+
+class CaseRunCreate(BaseModel):
+    """Payload for creating a case run."""
+
+    case_id: str = Field(description="Content-addressed case ID (SHA-256 hash)")
+    handler_fqn: str = Field(description="Fully qualified name of the case handler")
+    inputs: dict[str, Any] = Field(description="Case input parameters")
+
+
+class CaseRun(BaseModel):
+    """A single case execution within a study."""
+
+    case_id: str = Field(description="Content-addressed case ID (SHA-256 hash)")
+    handler_fqn: str = Field(description="Fully qualified name of the case handler")
+    inputs: dict[str, Any] = Field(description="Case input parameters")
+    status: CaseStatus = CaseStatus.pending
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    duration_seconds: float | None = None
+    results: dict[str, Any] = Field(default_factory=dict)
+    environment: dict[str, str] = Field(default_factory=dict)
+    error_message: str | None = None
+
+
+class HandlerSchema(BaseModel):
+    """A handler schema included with a study."""
+
+    name: str = Field(description="Handler class name")
+    schema_fingerprint: str = Field(description="Content-addressed fingerprint (SHA-256[:16])")
+    schema_: dict[str, Any] = Field(alias="schema", description="Full JSON Schema")
+
+
+class StudyCreate(BaseModel):
+    """Payload for creating/registering a study."""
+
+    name: str
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    plugins_declared: list[str] = Field(default_factory=list)
+    handlers: list[HandlerSchema] = Field(default_factory=list)
+    cases: list[CaseRunCreate] = Field(default_factory=list)
+
+
+class Study(BaseModel):
+    """A named, versioned collection of case runs."""
+
+    id: str
+    name: str
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    plugins_declared: list[str] = Field(default_factory=list)
+    handlers: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    cases: dict[str, CaseRun] = Field(default_factory=dict)
+    created_at: datetime
+    pushed_by: str | None = None
+
+
+class CaseStatusUpdate(BaseModel):
+    """Payload for updating a case's status."""
+
+    status: CaseStatus
+    duration_seconds: float | None = None
+    results: dict[str, Any] | None = None
+    environment: dict[str, str] | None = None
+    error_message: str | None = None
+
+
+class StudyResponse(BaseModel):
+    """API response format for study detail (matches UI expectations)."""
+
+    study_id: str
+    meta: dict[str, Any]
+    handlers: dict[str, dict[str, Any]]
+    pushed_at: datetime
+    pushed_by: str | None
+    runs: list[dict[str, Any]]
+
+    @classmethod
+    def from_study(cls, study: "Study") -> "StudyResponse":
+        runs = [
+            {
+                "case_id": case.case_id,
+                "handler": case.handler_fqn.split(".")[-1],
+                "inputs": case.inputs,
+                "status": case.status.value,
+                "started_at": case.started_at.isoformat() if case.started_at else None,
+                "completed_at": case.completed_at.isoformat() if case.completed_at else None,
+                "duration_seconds": case.duration_seconds,
+                "results": case.results,
+                "environment": case.environment,
+            }
+            for case in study.cases.values()
+        ]
+        return cls(
+            study_id=study.id,
+            meta={
+                "name": study.name,
+                "description": study.description,
+                "tags": study.tags,
+                "plugins": study.plugins_declared,
+            },
+            handlers=study.handlers,
+            pushed_at=study.created_at,
+            pushed_by=study.pushed_by,
+            runs=runs,
+        )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from pydantic import Field
 
 
 class User(BaseModel):

--- a/app/services/study_service.py
+++ b/app/services/study_service.py
@@ -1,0 +1,191 @@
+"""Study service for managing study and case records."""
+
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.database.models import Case, Study
+from app.schemas import (
+    CaseRun,
+    CaseStatus,
+    CaseStatusUpdate,
+    StudyCreate,
+)
+from app.schemas import (
+    Study as StudySchema,
+)
+
+
+def _orm_case_to_schema(case: Case) -> CaseRun:
+    return CaseRun(
+        case_id=case.case_id,
+        handler_fqn=case.handler_fqn,
+        inputs=json.loads(case.inputs) if case.inputs else {},
+        status=CaseStatus(case.status),
+        started_at=case.started_at,
+        completed_at=case.completed_at,
+        duration_seconds=case.duration_seconds,
+        results=json.loads(case.results) if case.results else {},
+        error_message=case.error_message,
+        environment=json.loads(case.environment) if case.environment else {},
+    )
+
+
+def _orm_study_to_schema(study: Study) -> StudySchema:
+    cases = {c.case_id: _orm_case_to_schema(c) for c in study.cases}
+    return StudySchema(
+        id=study.id,
+        name=study.name,
+        description=study.description,
+        tags=json.loads(study.tags) if study.tags else [],
+        plugins_declared=json.loads(study.plugins_declared) if study.plugins_declared else [],
+        handlers=json.loads(study.handlers) if study.handlers else {},
+        created_at=study.created_at,
+        pushed_by=study.pushed_by,
+        cases=cases,
+    )
+
+
+async def create_study(
+    db: AsyncSession, payload: StudyCreate, pushed_by: str | None = None
+) -> StudySchema:
+    study_id = str(uuid4())
+    handlers_dict = {h.schema_fingerprint: h.schema_ for h in payload.handlers}
+
+    study = Study(
+        id=study_id,
+        name=payload.name,
+        description=payload.description,
+        tags=json.dumps(payload.tags),
+        plugins_declared=json.dumps(payload.plugins_declared),
+        handlers=json.dumps(handlers_dict),
+        pushed_by=pushed_by,
+    )
+    db.add(study)
+
+    for c in payload.cases:
+        db.add(
+            Case(
+                study_id=study_id,
+                case_id=c.case_id,
+                handler_fqn=c.handler_fqn,
+                inputs=json.dumps(c.inputs),
+                status="pending",
+            )
+        )
+
+    await db.commit()
+
+    result = await db.execute(
+        select(Study).where(Study.id == study_id).options(selectinload(Study.cases))
+    )
+    study = result.scalar_one()
+    return _orm_study_to_schema(study)
+
+
+async def get_study(db: AsyncSession, study_id: str) -> StudySchema | None:
+    result = await db.execute(
+        select(Study).where(Study.id == study_id).options(selectinload(Study.cases))
+    )
+    study = result.scalar_one_or_none()
+    if study is None:
+        return None
+    return _orm_study_to_schema(study)
+
+
+async def get_all_studies(db: AsyncSession) -> list[StudySchema]:
+    result = await db.execute(
+        select(Study).order_by(Study.created_at.desc()).options(selectinload(Study.cases))
+    )
+    return [_orm_study_to_schema(s) for s in result.scalars().all()]
+
+
+async def update_study(
+    db: AsyncSession, study_id: str, payload: StudyCreate
+) -> StudySchema | None:
+    result = await db.execute(
+        select(Study).where(Study.id == study_id).options(selectinload(Study.cases))
+    )
+    study = result.scalar_one_or_none()
+    if study is None:
+        return None
+
+    handlers_dict = {h.schema_fingerprint: h.schema_ for h in payload.handlers}
+    study.name = payload.name
+    study.description = payload.description
+    study.tags = json.dumps(payload.tags)
+    study.plugins_declared = json.dumps(payload.plugins_declared)
+    study.handlers = json.dumps(handlers_dict)
+
+    # Upsert cases: update existing, insert new ones
+    existing = {c.case_id: c for c in study.cases}
+    for c in payload.cases:
+        if c.case_id in existing:
+            orm_case = existing[c.case_id]
+            orm_case.handler_fqn = c.handler_fqn
+            orm_case.inputs = json.dumps(c.inputs)
+        else:
+            db.add(
+                Case(
+                    study_id=study_id,
+                    case_id=c.case_id,
+                    handler_fqn=c.handler_fqn,
+                    inputs=json.dumps(c.inputs),
+                    status="pending",
+                )
+            )
+
+    await db.commit()
+    db.expire_all()
+
+    result = await db.execute(
+        select(Study).where(Study.id == study_id).options(selectinload(Study.cases))
+    )
+    study = result.scalar_one()
+    return _orm_study_to_schema(study)
+
+
+async def delete_study(db: AsyncSession, study_id: str) -> bool:
+    result = await db.execute(select(Study).where(Study.id == study_id))
+    study = result.scalar_one_or_none()
+    if study is None:
+        return False
+    await db.delete(study)
+    await db.commit()
+    return True
+
+
+async def update_case_status(
+    db: AsyncSession, study_id: str, case_id: str, update: CaseStatusUpdate
+) -> CaseRun | None:
+    result = await db.execute(
+        select(Case).where(Case.study_id == study_id, Case.case_id == case_id)
+    )
+    case = result.scalar_one_or_none()
+    if case is None:
+        return None
+
+    now = datetime.now(UTC)
+    case.status = update.status.value
+
+    if update.status == CaseStatus.running and case.started_at is None:
+        case.started_at = now
+    elif update.status in (CaseStatus.complete, CaseStatus.failed):
+        case.completed_at = now
+
+    if update.error_message is not None:
+        case.error_message = update.error_message
+    if update.duration_seconds is not None:
+        case.duration_seconds = update.duration_seconds
+    if update.results is not None:
+        case.results = json.dumps(update.results)
+    if update.environment is not None:
+        case.environment = json.dumps(update.environment)
+
+    await db.commit()
+    await db.refresh(case)
+    return _orm_case_to_schema(case)

--- a/app/services/study_service.py
+++ b/app/services/study_service.py
@@ -3,7 +3,6 @@
 import json
 from datetime import UTC
 from datetime import datetime
-from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,11 +50,9 @@ def _orm_study_to_schema(study: Study) -> StudySchema:
 async def create_study(
     db: AsyncSession, payload: StudyCreate, pushed_by: str | None = None
 ) -> StudySchema:
-    study_id = str(uuid4())
     handlers_dict = {h.schema_fingerprint: h.schema_ for h in payload.handlers}
 
     study = Study(
-        id=study_id,
         name=payload.name,
         description=payload.description,
         tags=json.dumps(payload.tags),
@@ -64,11 +61,12 @@ async def create_study(
         pushed_by=pushed_by,
     )
     db.add(study)
+    await db.flush()  # populate study.id from ORM default
 
     for c in payload.cases:
         db.add(
             Case(
-                study_id=study_id,
+                study_id=study.id,
                 case_id=c.case_id,
                 handler_fqn=c.handler_fqn,
                 inputs=json.dumps(c.inputs),
@@ -79,7 +77,7 @@ async def create_study(
     await db.commit()
 
     result = await db.execute(
-        select(Study).where(Study.id == study_id).options(selectinload(Study.cases))
+        select(Study).where(Study.id == study.id).options(selectinload(Study.cases))
     )
     study = result.scalar_one()
     return _orm_study_to_schema(study)

--- a/app/services/study_service.py
+++ b/app/services/study_service.py
@@ -1,23 +1,21 @@
 """Study service for managing study and case records."""
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC
+from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.database.models import Case, Study
-from app.schemas import (
-    CaseRun,
-    CaseStatus,
-    CaseStatusUpdate,
-    StudyCreate,
-)
-from app.schemas import (
-    Study as StudySchema,
-)
+from app.database.models import Case
+from app.database.models import Study
+from app.schemas import CaseRun
+from app.schemas import CaseStatus
+from app.schemas import CaseStatusUpdate
+from app.schemas import Study as StudySchema
+from app.schemas import StudyCreate
 
 
 def _orm_case_to_schema(case: Case) -> CaseRun:

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -16,14 +16,14 @@ async def get_or_create_user(
 
     If the user already exists, returns them unchanged.
     """
-    result = await db.execute(select(User).where(User.github_id == github_id))
+    result = await db.execute(select(User).where(User.github_id == str(github_id)))
     user = result.scalar_one_or_none()
 
     if user:
         return user
 
     user = User(
-        github_id=github_id,
+        github_id=str(github_id),
         username=username,
         avatar_url=avatar_url,
     )
@@ -33,7 +33,7 @@ async def get_or_create_user(
     return user
 
 
-async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
+async def get_user_by_id(db: AsyncSession, user_id: str) -> User | None:
     """Get a user by their database ID."""
     result = await db.execute(select(User).where(User.id == user_id))
     return result.scalar_one_or_none()
@@ -41,5 +41,5 @@ async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
 
 async def get_user_by_github_id(db: AsyncSession, github_id: int) -> User | None:
     """Get a user by their GitHub ID."""
-    result = await db.execute(select(User).where(User.github_id == github_id))
+    result = await db.execute(select(User).where(User.github_id == str(github_id)))
     return result.scalar_one_or_none()

--- a/migrations/versions/b933dc56a3e2_add_studies_and_cases_tables.py
+++ b/migrations/versions/b933dc56a3e2_add_studies_and_cases_tables.py
@@ -20,7 +20,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.create_table(
         "studies",
-        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("tags", sa.Text(), nullable=True),
@@ -32,8 +32,7 @@ def upgrade() -> None:
     )
     op.create_table(
         "cases",
-        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
-        sa.Column("study_id", sa.String(length=36), nullable=False),
+        sa.Column("study_id", sa.Uuid(), nullable=False),
         sa.Column("case_id", sa.String(length=64), nullable=False),
         sa.Column("handler_fqn", sa.Text(), nullable=False),
         sa.Column("inputs", sa.Text(), nullable=True),
@@ -45,12 +44,10 @@ def upgrade() -> None:
         sa.Column("error_message", sa.Text(), nullable=True),
         sa.Column("environment", sa.Text(), nullable=True),
         sa.ForeignKeyConstraint(["study_id"], ["studies.id"]),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("study_id", "case_id"),
     )
-    op.create_index(op.f("ix_cases_study_id"), "cases", ["study_id"], unique=False)
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix_cases_study_id"), table_name="cases")
     op.drop_table("cases")
     op.drop_table("studies")

--- a/migrations/versions/b933dc56a3e2_add_studies_and_cases_tables.py
+++ b/migrations/versions/b933dc56a3e2_add_studies_and_cases_tables.py
@@ -1,0 +1,56 @@
+"""Add studies and cases tables
+
+Revision ID: b933dc56a3e2
+Revises: 742059394c24
+Create Date: 2026-08-25 11:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b933dc56a3e2"
+down_revision: str | Sequence[str] | None = "742059394c24"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "studies",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("tags", sa.Text(), nullable=True),
+        sa.Column("plugins_declared", sa.Text(), nullable=True),
+        sa.Column("handlers", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("pushed_by", sa.String(length=255), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "cases",
+        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("study_id", sa.String(length=36), nullable=False),
+        sa.Column("case_id", sa.String(length=64), nullable=False),
+        sa.Column("handler_fqn", sa.Text(), nullable=False),
+        sa.Column("inputs", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="pending"),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("duration_seconds", sa.Float(), nullable=True),
+        sa.Column("results", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("environment", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["study_id"], ["studies.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_cases_study_id"), "cases", ["study_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_cases_study_id"), table_name="cases")
+    op.drop_table("cases")
+    op.drop_table("studies")

--- a/migrations/versions/ee252c2d7beb_change_user_id_to_uuid.py
+++ b/migrations/versions/ee252c2d7beb_change_user_id_to_uuid.py
@@ -1,0 +1,80 @@
+"""Change User.id and Study.id to UUID primary keys
+
+Revision ID: ee252c2d7beb
+Revises: b933dc56a3e2
+Create Date: 2026-08-25 12:30:00.000000
+
+Migrates the users table id column from Integer to Uuid.
+The studies and cases tables were created with Uuid in revision b933dc56a3e2.
+
+Note: SQLite does not support ALTER COLUMN, so this migration recreates
+the users table with the new schema.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "ee252c2d7beb"
+down_revision: str | Sequence[str] | None = "b933dc56a3e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Recreate users table with Uuid PK (SQLite does not support ALTER COLUMN)
+    op.create_table(
+        "users_new",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("github_id", sa.String(length=255), nullable=False),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column("avatar_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_new_github_id"), "users_new", ["github_id"], unique=True)
+
+    # Copy existing rows, generating UUIDs for the new id column
+    op.execute(
+        "INSERT INTO users_new (id, github_id, username, avatar_url, created_at, updated_at) "
+        "SELECT lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || "
+        "       substr(lower(hex(randomblob(2))),2) || '-' || "
+        "       substr('89ab', abs(random()) % 4 + 1, 1) || "
+        "       substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6))), "
+        "       CAST(github_id AS TEXT), username, avatar_url, created_at, updated_at "
+        "FROM users"
+    )
+
+    op.drop_index(op.f("ix_users_github_id"), table_name="users")
+    op.drop_table("users")
+    op.rename_table("users_new", "users")
+    op.execute("DROP INDEX IF EXISTS ix_users_new_github_id")
+    op.create_index(op.f("ix_users_github_id"), "users", ["github_id"], unique=True)
+
+
+def downgrade() -> None:
+    op.create_table(
+        "users_old",
+        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("github_id", sa.Integer(), nullable=False),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column("avatar_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_old_github_id"), "users_old", ["github_id"], unique=True)
+
+    op.execute(
+        "INSERT INTO users_old (github_id, username, avatar_url, created_at, updated_at) "
+        "SELECT CAST(github_id AS INTEGER), username, avatar_url, created_at, updated_at "
+        "FROM users"
+    )
+
+    op.drop_index(op.f("ix_users_github_id"), table_name="users")
+    op.drop_table("users")
+    op.rename_table("users_old", "users")
+    op.execute("DROP INDEX IF EXISTS ix_users_old_github_id")
+    op.create_index(op.f("ix_users_github_id"), "users", ["github_id"], unique=True)

--- a/tests/test_studies_api.py
+++ b/tests/test_studies_api.py
@@ -1,0 +1,218 @@
+"""Tests for the Study API endpoints."""
+
+from httpx import AsyncClient
+
+STUDY_PAYLOAD = {
+    "name": "test-study",
+    "description": "A test study",
+    "tags": ["test", "unit"],
+    "plugins_declared": ["lembas-planing-plate"],
+    "cases": [
+        {
+            "case_id": "abc123",
+            "handler_fqn": "lembas_planing_plate.PlaningPlateCase",
+            "inputs": {"froude_num": 0.5, "angle_of_attack": 5.0},
+        },
+        {
+            "case_id": "def456",
+            "handler_fqn": "lembas_planing_plate.PlaningPlateCase",
+            "inputs": {"froude_num": 0.8, "angle_of_attack": 10.0},
+        },
+    ],
+}
+
+
+async def test_create_study(client: AsyncClient) -> None:
+    response = await client.post("/api/studies", json=STUDY_PAYLOAD)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["name"] == "test-study"
+    assert data["description"] == "A test study"
+    assert data["tags"] == ["test", "unit"]
+    assert len(data["cases"]) == 2
+    assert "abc123" in data["cases"]
+    assert "def456" in data["cases"]
+    assert data["cases"]["abc123"]["status"] == "pending"
+    assert data["cases"]["abc123"]["inputs"] == {"froude_num": 0.5, "angle_of_attack": 5.0}
+    assert "id" in data
+    assert "created_at" in data
+
+
+async def test_get_study(client: AsyncClient) -> None:
+    create_resp = await client.post("/api/studies", json={"name": "fetch-test", "cases": [
+        {"case_id": "xyz789", "handler_fqn": "test.Case", "inputs": {}}
+    ]})
+    assert create_resp.status_code == 201
+    study_id = create_resp.json()["id"]
+
+    response = await client.get(f"/api/studies/{study_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == study_id
+    assert data["name"] == "fetch-test"
+    assert "xyz789" in data["cases"]
+
+
+async def test_get_study_not_found(client: AsyncClient) -> None:
+    response = await client.get("/api/studies/nonexistent-id")
+    assert response.status_code == 404
+
+
+async def test_update_study(client: AsyncClient) -> None:
+    create_resp = await client.post("/api/studies", json={"name": "update-test", "cases": [
+        {"case_id": "case-a", "handler_fqn": "test.Case", "inputs": {"x": 1}}
+    ]})
+    assert create_resp.status_code == 201
+    study_id = create_resp.json()["id"]
+
+    # Update study: rename, add a new case
+    update_payload = {
+        "name": "update-test-renamed",
+        "cases": [
+            {"case_id": "case-a", "handler_fqn": "test.Case", "inputs": {"x": 2}},
+            {"case_id": "case-b", "handler_fqn": "test.Case", "inputs": {"x": 3}},
+        ],
+    }
+    response = await client.put(f"/api/studies/{study_id}", json=update_payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "update-test-renamed"
+    assert len(data["cases"]) == 2
+    assert "case-b" in data["cases"]
+    # Existing case inputs should be updated
+    assert data["cases"]["case-a"]["inputs"] == {"x": 2}
+
+
+async def test_update_study_not_found(client: AsyncClient) -> None:
+    response = await client.put(
+        "/api/studies/nonexistent-id", json={"name": "x", "cases": []}
+    )
+    assert response.status_code == 404
+
+
+async def test_delete_study(client: AsyncClient) -> None:
+    create_resp = await client.post("/api/studies", json={"name": "delete-test", "cases": []})
+    assert create_resp.status_code == 201
+    study_id = create_resp.json()["id"]
+
+    response = await client.delete(f"/api/studies/{study_id}")
+    assert response.status_code == 204
+
+    # Verify it's gone
+    response = await client.get(f"/api/studies/{study_id}")
+    assert response.status_code == 404
+
+
+async def test_delete_study_not_found(client: AsyncClient) -> None:
+    response = await client.delete("/api/studies/nonexistent-id")
+    assert response.status_code == 404
+
+
+async def test_get_study_detail(client: AsyncClient) -> None:
+    create_resp = await client.post("/api/studies", json={"name": "detail-test", "cases": [
+        {"case_id": "c1", "handler_fqn": "test.Case", "inputs": {"param": "value"}}
+    ]})
+    assert create_resp.status_code == 201
+    study_id = create_resp.json()["id"]
+
+    response = await client.get(f"/api/studies/{study_id}/detail")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["study_id"] == study_id
+    assert data["meta"]["name"] == "detail-test"
+    assert len(data["runs"]) == 1
+    assert data["runs"][0]["case_id"] == "c1"
+    assert data["runs"][0]["status"] == "pending"
+
+
+async def test_update_case_status_to_running(client: AsyncClient) -> None:
+    create_resp = await client.post("/api/studies", json={"name": "status-test", "cases": [
+        {"case_id": "case001", "handler_fqn": "test.Case", "inputs": {}}
+    ]})
+    assert create_resp.status_code == 201
+    study_id = create_resp.json()["id"]
+
+    response = await client.patch(
+        f"/api/studies/{study_id}/cases/case001",
+        json={"status": "running"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["case"]["status"] == "running"
+    assert data["case"]["started_at"] is not None
+
+
+async def test_update_case_status_to_complete(client: AsyncClient) -> None:
+    create_resp = await client.post("/api/studies", json={"name": "complete-test", "cases": [
+        {"case_id": "case002", "handler_fqn": "test.Case", "inputs": {}}
+    ]})
+    assert create_resp.status_code == 201
+    study_id = create_resp.json()["id"]
+
+    # running → complete
+    await client.patch(
+        f"/api/studies/{study_id}/cases/case002", json={"status": "running"}
+    )
+    response = await client.patch(
+        f"/api/studies/{study_id}/cases/case002",
+        json={"status": "complete", "duration_seconds": 1.5, "results": {"lift": 42.0}},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["case"]["status"] == "complete"
+    assert data["case"]["completed_at"] is not None
+    assert data["case"]["duration_seconds"] == 1.5
+    assert data["case"]["results"] == {"lift": 42.0}
+
+
+async def test_update_case_status_failed_with_error(client: AsyncClient) -> None:
+    create_resp = await client.post("/api/studies", json={"name": "fail-test", "cases": [
+        {"case_id": "case003", "handler_fqn": "test.Case", "inputs": {}}
+    ]})
+    assert create_resp.status_code == 201
+    study_id = create_resp.json()["id"]
+
+    response = await client.patch(
+        f"/api/studies/{study_id}/cases/case003",
+        json={"status": "failed", "error_message": "Something went wrong"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["case"]["status"] == "failed"
+    assert data["case"]["error_message"] == "Something went wrong"
+
+
+async def test_update_case_status_not_found(client: AsyncClient) -> None:
+    response = await client.patch(
+        "/api/studies/nonexistent-id/cases/case001",
+        json={"status": "running"},
+    )
+    assert response.status_code == 404
+
+
+async def test_study_with_handler_schemas(client: AsyncClient) -> None:
+    """Test that handler schemas are stored and returned with the study."""
+    payload = {
+        "name": "schema-test",
+        "handlers": [
+            {
+                "name": "PlaningPlateCase",
+                "schema": {
+                    "title": "PlaningPlateCase",
+                    "inputs": {"properties": {"froude_num": {"type": "number"}}},
+                    "results": {"properties": {"lift": {"type": "number"}}},
+                    "steps": [],
+                },
+                "schema_fingerprint": "abcdef012345",
+            }
+        ],
+        "cases": [
+            {"case_id": "h1", "handler_fqn": "test.PlaningPlateCase", "inputs": {}}
+        ],
+    }
+    response = await client.post("/api/studies", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert "abcdef012345" in data["handlers"]
+    assert data["handlers"]["abcdef012345"]["title"] == "PlaningPlateCase"

--- a/tests/test_studies_api.py
+++ b/tests/test_studies_api.py
@@ -40,9 +40,13 @@ async def test_create_study(client: AsyncClient) -> None:
 
 
 async def test_get_study(client: AsyncClient) -> None:
-    create_resp = await client.post("/api/studies", json={"name": "fetch-test", "cases": [
-        {"case_id": "xyz789", "handler_fqn": "test.Case", "inputs": {}}
-    ]})
+    create_resp = await client.post(
+        "/api/studies",
+        json={
+            "name": "fetch-test",
+            "cases": [{"case_id": "xyz789", "handler_fqn": "test.Case", "inputs": {}}],
+        },
+    )
     assert create_resp.status_code == 201
     study_id = create_resp.json()["id"]
 
@@ -60,9 +64,13 @@ async def test_get_study_not_found(client: AsyncClient) -> None:
 
 
 async def test_update_study(client: AsyncClient) -> None:
-    create_resp = await client.post("/api/studies", json={"name": "update-test", "cases": [
-        {"case_id": "case-a", "handler_fqn": "test.Case", "inputs": {"x": 1}}
-    ]})
+    create_resp = await client.post(
+        "/api/studies",
+        json={
+            "name": "update-test",
+            "cases": [{"case_id": "case-a", "handler_fqn": "test.Case", "inputs": {"x": 1}}],
+        },
+    )
     assert create_resp.status_code == 201
     study_id = create_resp.json()["id"]
 
@@ -85,9 +93,7 @@ async def test_update_study(client: AsyncClient) -> None:
 
 
 async def test_update_study_not_found(client: AsyncClient) -> None:
-    response = await client.put(
-        "/api/studies/nonexistent-id", json={"name": "x", "cases": []}
-    )
+    response = await client.put("/api/studies/nonexistent-id", json={"name": "x", "cases": []})
     assert response.status_code == 404
 
 
@@ -110,9 +116,13 @@ async def test_delete_study_not_found(client: AsyncClient) -> None:
 
 
 async def test_get_study_detail(client: AsyncClient) -> None:
-    create_resp = await client.post("/api/studies", json={"name": "detail-test", "cases": [
-        {"case_id": "c1", "handler_fqn": "test.Case", "inputs": {"param": "value"}}
-    ]})
+    create_resp = await client.post(
+        "/api/studies",
+        json={
+            "name": "detail-test",
+            "cases": [{"case_id": "c1", "handler_fqn": "test.Case", "inputs": {"param": "value"}}],
+        },
+    )
     assert create_resp.status_code == 201
     study_id = create_resp.json()["id"]
 
@@ -127,9 +137,13 @@ async def test_get_study_detail(client: AsyncClient) -> None:
 
 
 async def test_update_case_status_to_running(client: AsyncClient) -> None:
-    create_resp = await client.post("/api/studies", json={"name": "status-test", "cases": [
-        {"case_id": "case001", "handler_fqn": "test.Case", "inputs": {}}
-    ]})
+    create_resp = await client.post(
+        "/api/studies",
+        json={
+            "name": "status-test",
+            "cases": [{"case_id": "case001", "handler_fqn": "test.Case", "inputs": {}}],
+        },
+    )
     assert create_resp.status_code == 201
     study_id = create_resp.json()["id"]
 
@@ -144,16 +158,18 @@ async def test_update_case_status_to_running(client: AsyncClient) -> None:
 
 
 async def test_update_case_status_to_complete(client: AsyncClient) -> None:
-    create_resp = await client.post("/api/studies", json={"name": "complete-test", "cases": [
-        {"case_id": "case002", "handler_fqn": "test.Case", "inputs": {}}
-    ]})
+    create_resp = await client.post(
+        "/api/studies",
+        json={
+            "name": "complete-test",
+            "cases": [{"case_id": "case002", "handler_fqn": "test.Case", "inputs": {}}],
+        },
+    )
     assert create_resp.status_code == 201
     study_id = create_resp.json()["id"]
 
     # running → complete
-    await client.patch(
-        f"/api/studies/{study_id}/cases/case002", json={"status": "running"}
-    )
+    await client.patch(f"/api/studies/{study_id}/cases/case002", json={"status": "running"})
     response = await client.patch(
         f"/api/studies/{study_id}/cases/case002",
         json={"status": "complete", "duration_seconds": 1.5, "results": {"lift": 42.0}},
@@ -167,9 +183,13 @@ async def test_update_case_status_to_complete(client: AsyncClient) -> None:
 
 
 async def test_update_case_status_failed_with_error(client: AsyncClient) -> None:
-    create_resp = await client.post("/api/studies", json={"name": "fail-test", "cases": [
-        {"case_id": "case003", "handler_fqn": "test.Case", "inputs": {}}
-    ]})
+    create_resp = await client.post(
+        "/api/studies",
+        json={
+            "name": "fail-test",
+            "cases": [{"case_id": "case003", "handler_fqn": "test.Case", "inputs": {}}],
+        },
+    )
     assert create_resp.status_code == 201
     study_id = create_resp.json()["id"]
 
@@ -207,9 +227,7 @@ async def test_study_with_handler_schemas(client: AsyncClient) -> None:
                 "schema_fingerprint": "abcdef012345",
             }
         ],
-        "cases": [
-            {"case_id": "h1", "handler_fqn": "test.PlaningPlateCase", "inputs": {}}
-        ],
+        "cases": [{"case_id": "h1", "handler_fqn": "test.PlaningPlateCase", "inputs": {}}],
     }
     response = await client.post("/api/studies", json=payload)
     assert response.status_code == 201

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -16,7 +16,7 @@ async def test_create_new_user(db: AsyncSession) -> None:
     )
 
     assert user.id is not None
-    assert user.github_id == 1000001
+    assert user.github_id == "1000001"
     assert user.username == "newuser"
     assert user.avatar_url == "https://example.com/avatar.png"
 
@@ -68,7 +68,7 @@ async def test_get_user_by_id(db: AsyncSession) -> None:
     assert found is not None
     assert found.username == "findme"
 
-    not_found = await get_user_by_id(db, 999999)
+    not_found = await get_user_by_id(db, "nonexistent-uuid")
     assert not_found is None
 
 


### PR DESCRIPTION
Switches all ORM models from integer to UUID primary keys for consistency and future-proofing.

## Changes

- **`User.id`**: `Integer` → `Uuid` (generated by `_new_uuid()` ORM default)
- **`User.github_id`**: `Integer` → `String(255)` (coerced on write in service)
- **`Study.id`**: `String(36)` → `Uuid` (ORM-generated; removed manual `uuid4()` from service)
- **`Case`**: dropped integer surrogate `id` → composite primary key `(study_id, case_id)`
- **`migrations/ee252c2d7beb`**: recreates `users` table with UUID PK (SQLite table-rebuild pattern)
- **`migrations/b933dc56a3e2`**: updated in-place to use `Uuid` columns and composite PK for `cases`