### PR TITLE
chore(db): Use UUID primary key for User, store github_id as string

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -3,9 +3,9 @@
 from datetime import UTC
 from datetime import datetime
 from typing import Any
+from uuid import uuid4
 
 from sqlalchemy import DateTime
-from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy import TypeDecorator
@@ -13,6 +13,7 @@ from sqlalchemy.engine import Dialect
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
+from sqlalchemy.types import Uuid
 
 
 class TZDateTime(TypeDecorator[datetime]):
@@ -36,6 +37,10 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
+def _new_uuid() -> str:
+    return str(uuid4())
+
+
 class Base(DeclarativeBase):
     pass
 
@@ -43,8 +48,8 @@ class Base(DeclarativeBase):
 class User(Base):
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    github_id: Mapped[int] = mapped_column(Integer, unique=True, nullable=False, index=True)
+    id: Mapped[str] = mapped_column(Uuid(as_uuid=False), primary_key=True, default=_new_uuid)
+    github_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     username: Mapped[str] = mapped_column(String(255), nullable=False)
     avatar_url: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(TZDateTime, default=_utc_now)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -16,14 +16,14 @@ async def get_or_create_user(
 
     If the user already exists, returns them unchanged.
     """
-    result = await db.execute(select(User).where(User.github_id == github_id))
+    result = await db.execute(select(User).where(User.github_id == str(github_id)))
     user = result.scalar_one_or_none()
 
     if user:
         return user
 
     user = User(
-        github_id=github_id,
+        github_id=str(github_id),
         username=username,
         avatar_url=avatar_url,
     )
@@ -33,7 +33,7 @@ async def get_or_create_user(
     return user
 
 
-async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
+async def get_user_by_id(db: AsyncSession, user_id: str) -> User | None:
     """Get a user by their database ID."""
     result = await db.execute(select(User).where(User.id == user_id))
     return result.scalar_one_or_none()
@@ -41,5 +41,5 @@ async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
 
 async def get_user_by_github_id(db: AsyncSession, github_id: int) -> User | None:
     """Get a user by their GitHub ID."""
-    result = await db.execute(select(User).where(User.github_id == github_id))
+    result = await db.execute(select(User).where(User.github_id == str(github_id)))
     return result.scalar_one_or_none()

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -40,16 +40,26 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
-    url = get_url()
+    # Allow pytest-alembic to inject a connection at runtime
+    connectable = context.config.attributes.get("connection", None)
 
-    if url.startswith("sqlite:///") and not url.endswith(":memory:"):
-        db_path = url.replace("sqlite:///", "")
-        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    if connectable is None:
+        url = get_url()
 
-    connectable = create_engine(url, poolclass=pool.NullPool)
+        if url.startswith("sqlite:///") and not url.endswith(":memory:"):
+            db_path = url.replace("sqlite:///", "")
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        connectable = create_engine(url, poolclass=pool.NullPool)
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            include_object=lambda obj, name, type_, *args, **kw: (
+                type_ != "table" or name in target_metadata.tables
+            ),
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/migrations/versions/ee252c2d7beb_change_user_id_to_uuid.py
+++ b/migrations/versions/ee252c2d7beb_change_user_id_to_uuid.py
@@ -1,0 +1,80 @@
+"""Change User.id to UUID primary key, store github_id as string
+
+Revision ID: ee252c2d7beb
+Revises: 742059394c24
+Create Date: 2026-08-25 12:30:00.000000
+
+Migrates the users table id column from Integer to Uuid and
+github_id from Integer to String.
+
+Note: SQLite does not support ALTER COLUMN, so this migration recreates
+the users table with the new schema.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "ee252c2d7beb"
+down_revision: str | Sequence[str] | None = "742059394c24"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Recreate users table with Uuid PK (SQLite does not support ALTER COLUMN)
+    op.create_table(
+        "users_new",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("github_id", sa.String(length=255), nullable=False),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column("avatar_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_new_github_id"), "users_new", ["github_id"], unique=True)
+
+    # Copy existing rows, generating UUIDs for the new id column
+    op.execute(
+        "INSERT INTO users_new (id, github_id, username, avatar_url, created_at, updated_at) "
+        "SELECT lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || "
+        "       substr(lower(hex(randomblob(2))),2) || '-' || "
+        "       substr('89ab', abs(random()) % 4 + 1, 1) || "
+        "       substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6))), "
+        "       CAST(github_id AS TEXT), username, avatar_url, created_at, updated_at "
+        "FROM users"
+    )
+
+    op.drop_index(op.f("ix_users_github_id"), table_name="users")
+    op.drop_table("users")
+    op.rename_table("users_new", "users")
+    op.execute("DROP INDEX IF EXISTS ix_users_new_github_id")
+    op.create_index(op.f("ix_users_github_id"), "users", ["github_id"], unique=True)
+
+
+def downgrade() -> None:
+    op.create_table(
+        "users_old",
+        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("github_id", sa.Integer(), nullable=False),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column("avatar_url", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_users_old_github_id"), "users_old", ["github_id"], unique=True)
+
+    op.execute(
+        "INSERT INTO users_old (github_id, username, avatar_url, created_at, updated_at) "
+        "SELECT CAST(github_id AS INTEGER), username, avatar_url, created_at, updated_at "
+        "FROM users"
+    )
+
+    op.drop_index(op.f("ix_users_github_id"), table_name="users")
+    op.drop_table("users")
+    op.rename_table("users_old", "users")
+    op.execute("DROP INDEX IF EXISTS ix_users_old_github_id")
+    op.create_index(op.f("ix_users_github_id"), "users", ["github_id"], unique=True)

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,16 +1,7 @@
 version: 7
 platforms:
 - name: linux-64
-  virtual-packages:
-  - __unix=0=0
-  - __linux=4.18
-  - __glibc=2.28
-  - __archspec=0=x86_64
 - name: osx-arm64
-  virtual-packages:
-  - __unix=0=0
-  - __osx=13.0
-  - __archspec=0=m1
 environments:
   default:
     channels:
@@ -108,6 +99,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-alembic-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-asyncio-1.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -184,6 +176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-alembic-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-asyncio-1.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
@@ -1484,6 +1477,19 @@ packages:
   run_exports: {}
   size: 306724
   timestamp: 1782127176429
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-alembic-0.12.1-pyhd8ed1ab_0.conda
+  sha256: 3a91806736ee24ded176f23402118b31a6eeab7f45672c757c680166bae6126e
+  md5: 1d03f206f0e97a1d9819ff2ce10af1ac
+  depends:
+  - alembic
+  - pytest >=7.0
+  - python >=3.9
+  - sqlalchemy
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 30913
+  timestamp: 1748384250897
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-asyncio-1.4.0-pyhcf101f3_0.conda
   sha256: 1eddccab8f91f718f890a2aabfc25e68c37a6171fb120e4ec4df7a5a96a877e9
   md5: 787319c0ace4c39b7e883a86332db6a4

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,6 +17,7 @@ default = {features = ["dev"], solve-group = "default"}
 mypy = "*"
 pre-commit = ">=4"
 pytest = ">=8"
+pytest-alembic = "*"
 pytest-asyncio = "*"
 pytest-env = "*"
 pytest-mock = "*"
@@ -25,7 +26,7 @@ ruff = "*"
 [tasks]
 dev = "uvicorn app.main:app --reload --port 8001"
 lint = "ruff check app/ tests/"
-test = "pytest tests/"
+test = "pytest --test-alembic tests/"
 typecheck = "mypy"
 
 [workspace]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@ from collections.abc import Callable
 
 import httpx
 import pytest
+import sqlalchemy
 from fastapi import FastAPI
+from sqlalchemy import Engine
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import close_database
@@ -68,3 +70,9 @@ async def client_factory(app: FastAPI, base_url: str) -> AsyncIterator[ClientFac
 def client(client_factory: ClientFactory) -> httpx.AsyncClient:
     """An HTTP session."""
     return client_factory()
+
+
+@pytest.fixture
+def alembic_engine() -> Engine:
+    """Synchronous SQLite engine for pytest-alembic migration tests."""
+    return sqlalchemy.create_engine("sqlite://")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,14 +9,18 @@ import pytest
 from sqlalchemy import Integer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 
-from app.database.models import Base
 from app.database.models import TZDateTime
 
 
-class TimestampModel(Base):
+class _TestBase(DeclarativeBase):
+    pass
+
+
+class TimestampModel(_TestBase):
     """Test model for TZDateTime tests."""
 
     __tablename__ = "test_timestamps"

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -16,7 +16,7 @@ async def test_create_new_user(db: AsyncSession) -> None:
     )
 
     assert user.id is not None
-    assert user.github_id == 1000001
+    assert user.github_id == "1000001"
     assert user.username == "newuser"
     assert user.avatar_url == "https://example.com/avatar.png"
 
@@ -68,7 +68,7 @@ async def test_get_user_by_id(db: AsyncSession) -> None:
     assert found is not None
     assert found.username == "findme"
 
-    not_found = await get_user_by_id(db, 999999)
+    not_found = await get_user_by_id(db, "nonexistent-uuid")
     assert not_found is None
 
 


### PR DESCRIPTION
Migrates the `users` table to use a UUID primary key instead of an auto-increment integer, and stores `github_id` as `String(255)` instead of `Integer`.

## Changes

- **`app/database/models.py`** — `User.id`: `Integer` → `Uuid(as_uuid=False)` with `_new_uuid()` default; `github_id`: `Integer` → `String(255)`
- **`app/services/user_service.py`** — coerce `github_id` to `str` on read/write; `get_user_by_id` signature updated to `str`
- **`migrations/ee252c2d7beb`** — recreates `users` table with UUID PK via SQLite table-rebuild pattern
- **`tests/test_user_service.py`** — updated assertions to match new types

## Merge order
This should land before the studies/cases tables PR.