### PR TITLE
feat(auth): Add API token authentication

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -105,3 +105,20 @@ class Case(Base):
     environment: Mapped[str | None] = mapped_column(Text)  # JSON dict
 
     study: Mapped["Study"] = relationship("Study", back_populates="cases")
+
+
+class APIToken(Base):
+    """A long-lived API token associated with a user account."""
+
+    __tablename__ = "api_tokens"
+
+    id: Mapped[str] = mapped_column(Uuid(as_uuid=False), primary_key=True, default=_new_uuid)
+    user_id: Mapped[str] = mapped_column(
+        Uuid(as_uuid=False), ForeignKey("users.id"), nullable=False, index=True
+    )
+    token: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    name: Mapped[str | None] = mapped_column(String(255))  # optional human label
+    created_at: Mapped[datetime] = mapped_column(TZDateTime, default=_utc_now)
+    last_used_at: Mapped[datetime | None] = mapped_column(TZDateTime)
+
+    user: Mapped["User"] = relationship("User")

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -116,7 +116,7 @@ class APIToken(Base):
     user_id: Mapped[str] = mapped_column(
         Uuid(as_uuid=False), ForeignKey("users.id"), nullable=False, index=True
     )
-    token: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    token: Mapped[str] = mapped_column(String(80), unique=True, nullable=False, index=True)
     name: Mapped[str | None] = mapped_column(String(255))  # optional human label
     created_at: Mapped[datetime] = mapped_column(TZDateTime, default=_utc_now)
     last_used_at: Mapped[datetime | None] = mapped_column(TZDateTime)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,13 +3,18 @@ from typing import Annotated
 from fastapi import Cookie
 from fastapi import Depends
 from fastapi import Request
+from fastapi.security import HTTPAuthorizationCredentials
+from fastapi.security import HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_github_user_data
 from app.database import get_db
 from app.database.models import User
+from app.services.token_service import get_user_by_token
 from app.services.user_service import get_user_by_github_id
 from app.settings import Settings
+
+_bearer = HTTPBearer(auto_error=False)
 
 
 def config(request: Request) -> Settings:
@@ -19,9 +24,18 @@ def config(request: Request) -> Settings:
 async def current_user(
     config: Annotated[Settings, Depends(config)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    bearer: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)] = None,
     access_token: Annotated[str | None, Cookie()] = None,
 ) -> User | None:
-    """Resolve the ORM User row for the current authenticated user."""
+    """Resolve the ORM User for the current request.
+
+    Checks in order:
+    1. Authorization: Bearer <token> header — API token (for CLI/programmatic use)
+    2. access_token cookie — GitHub OAuth session (for browser use)
+    """
+    if bearer is not None:
+        return await get_user_by_token(db, bearer.credentials)
+
     if access_token is None:
         return None
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -23,8 +23,14 @@ from app.schemas import Page
 from app.schemas import Study
 from app.schemas import StudyCreatePayload
 from app.schemas import StudyResponse
+from app.schemas import TokenCreatePayload
+from app.schemas import TokenMetadata
+from app.schemas import TokenResponse
 from app.schemas import UserResponse
 from app.services import study_service
+from app.services.token_service import create_token
+from app.services.token_service import delete_token
+from app.services.token_service import list_tokens
 from app.services.user_service import get_all_users
 from app.services.user_service import get_or_create_user
 from app.settings import Settings
@@ -116,6 +122,65 @@ async def list_users(
     users = await get_all_users(db)
     items = [UserResponse(id=u.id, username=u.username, avatar_url=u.avatar_url) for u in users]
     return Page(items=items, total=len(items))
+
+
+# --- Token API Endpoints ---
+
+
+@api_router.post("/auth/tokens", status_code=status.HTTP_201_CREATED)
+async def create_api_token(
+    payload: TokenCreatePayload,
+    user: Annotated[User | None, Depends(current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> TokenResponse:
+    """Create a new API token for the authenticated user.
+
+    The token value is only returned once — store it securely.
+    Requires authentication via GitHub OAuth session.
+    """
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    token = await create_token(db, user, name=payload.name)
+    return TokenResponse(
+        id=token.id,
+        name=token.name,
+        token=token.token,
+        created_at=token.created_at,
+    )
+
+
+@api_router.get("/auth/tokens")
+async def list_api_tokens(
+    user: Annotated[User | None, Depends(current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[TokenMetadata]:
+    """List all API tokens for the authenticated user (no token values)."""
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    tokens = await list_tokens(db, user)
+    return [
+        TokenMetadata(
+            id=t.id,
+            name=t.name,
+            created_at=t.created_at,
+            last_used_at=t.last_used_at,
+        )
+        for t in tokens
+    ]
+
+
+@api_router.delete("/auth/tokens/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_api_token(
+    token_id: str,
+    user: Annotated[User | None, Depends(current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Revoke an API token. Only the owning user can delete their own tokens."""
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    deleted = await delete_token(db, token_id, user)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Token not found")
 
 
 # --- Study API Endpoints ---

--- a/app/routes.py
+++ b/app/routes.py
@@ -127,7 +127,7 @@ async def list_users(
 # --- Token API Endpoints ---
 
 
-@api_router.post("/auth/tokens", status_code=status.HTTP_201_CREATED)
+@api_router.post("/tokens", status_code=status.HTTP_201_CREATED)
 async def create_api_token(
     payload: TokenCreatePayload,
     user: Annotated[User | None, Depends(current_user)],
@@ -149,7 +149,7 @@ async def create_api_token(
     )
 
 
-@api_router.get("/auth/tokens")
+@api_router.get("/tokens")
 async def list_api_tokens(
     user: Annotated[User | None, Depends(current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -169,7 +169,7 @@ async def list_api_tokens(
     ]
 
 
-@api_router.delete("/auth/tokens/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+@api_router.delete("/tokens/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_api_token(
     token_id: str,
     user: Annotated[User | None, Depends(current_user)],

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -34,6 +34,30 @@ class UserResponse(BaseModel):
     avatar_url: str | None = None
 
 
+class TokenCreatePayload(BaseModel):
+    """Payload for creating an API token."""
+
+    name: str | None = Field(default=None, description="Optional human-readable label")
+
+
+class TokenResponse(BaseModel):
+    """Response after creating a token. The raw token is only returned once."""
+
+    id: str
+    name: str | None
+    token: str
+    created_at: datetime
+
+
+class TokenMetadata(BaseModel):
+    """Token metadata for listing — does not include the raw token value."""
+
+    id: str
+    name: str | None
+    created_at: datetime
+    last_used_at: datetime | None
+
+
 class CaseRunCreate(BaseModel):
     """Payload for creating a case run."""
 

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -1,0 +1,72 @@
+"""Service functions for API token management."""
+
+import secrets
+from datetime import UTC
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.database.models import APIToken
+from app.database.models import User
+
+
+def _generate_token() -> str:
+    """Generate a cryptographically secure 32-byte (64 hex char) token."""
+    return secrets.token_hex(32)
+
+
+async def create_token(
+    db: AsyncSession, user: User, name: str | None = None
+) -> APIToken:
+    """Create and persist a new API token for the given user."""
+    token = APIToken(
+        user_id=user.id,
+        token=_generate_token(),
+        name=name,
+    )
+    db.add(token)
+    await db.commit()
+    await db.refresh(token)
+    return token
+
+
+async def get_user_by_token(db: AsyncSession, raw_token: str) -> User | None:
+    """Look up the user associated with a raw token string, updating last_used_at."""
+    result = await db.execute(
+        select(APIToken)
+        .where(APIToken.token == raw_token)
+        .options(selectinload(APIToken.user))
+    )
+    api_token = result.scalar_one_or_none()
+    if api_token is None:
+        return None
+
+    api_token.last_used_at = datetime.now(UTC)
+    await db.commit()
+
+    return api_token.user
+
+
+async def list_tokens(db: AsyncSession, user: User) -> list[APIToken]:
+    """List all tokens for a user."""
+    result = await db.execute(
+        select(APIToken)
+        .where(APIToken.user_id == user.id)
+        .order_by(APIToken.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def delete_token(db: AsyncSession, token_id: str, user: User) -> bool:
+    """Delete a token by ID. Returns False if not found or not owned by user."""
+    result = await db.execute(
+        select(APIToken).where(APIToken.id == token_id, APIToken.user_id == user.id)
+    )
+    token = result.scalar_one_or_none()
+    if token is None:
+        return False
+    await db.delete(token)
+    await db.commit()
+    return True

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -11,10 +11,16 @@ from sqlalchemy.orm import selectinload
 from app.database.models import APIToken
 from app.database.models import User
 
+TOKEN_PREFIX = "lb_v1"
+
 
 def _generate_token() -> str:
-    """Generate a cryptographically secure 32-byte (64 hex char) token."""
-    return secrets.token_hex(32)
+    """Generate a prefixed, cryptographically secure token.
+
+    Format: lb_v1_<32 random bytes as hex>
+    Example: lb_v1_a3f1c9...
+    """
+    return f"{TOKEN_PREFIX}_{secrets.token_hex(32)}"
 
 
 async def create_token(db: AsyncSession, user: User, name: str | None = None) -> APIToken:

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -17,9 +17,7 @@ def _generate_token() -> str:
     return secrets.token_hex(32)
 
 
-async def create_token(
-    db: AsyncSession, user: User, name: str | None = None
-) -> APIToken:
+async def create_token(db: AsyncSession, user: User, name: str | None = None) -> APIToken:
     """Create and persist a new API token for the given user."""
     token = APIToken(
         user_id=user.id,
@@ -35,9 +33,7 @@ async def create_token(
 async def get_user_by_token(db: AsyncSession, raw_token: str) -> User | None:
     """Look up the user associated with a raw token string, updating last_used_at."""
     result = await db.execute(
-        select(APIToken)
-        .where(APIToken.token == raw_token)
-        .options(selectinload(APIToken.user))
+        select(APIToken).where(APIToken.token == raw_token).options(selectinload(APIToken.user))
     )
     api_token = result.scalar_one_or_none()
     if api_token is None:
@@ -52,9 +48,7 @@ async def get_user_by_token(db: AsyncSession, raw_token: str) -> User | None:
 async def list_tokens(db: AsyncSession, user: User) -> list[APIToken]:
     """List all tokens for a user."""
     result = await db.execute(
-        select(APIToken)
-        .where(APIToken.user_id == user.id)
-        .order_by(APIToken.created_at.desc())
+        select(APIToken).where(APIToken.user_id == user.id).order_by(APIToken.created_at.desc())
     )
     return list(result.scalars().all())
 

--- a/migrations/versions/f3a1c9e82d07_add_api_tokens_table.py
+++ b/migrations/versions/f3a1c9e82d07_add_api_tokens_table.py
@@ -1,0 +1,39 @@
+"""Add api_tokens table
+
+Revision ID: f3a1c9e82d07
+Revises: b933dc56a3e2
+Create Date: 2026-08-26 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f3a1c9e82d07"
+down_revision: str | Sequence[str] | None = "b933dc56a3e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_tokens",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("token", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_api_tokens_token"), "api_tokens", ["token"], unique=True)
+    op.create_index(op.f("ix_api_tokens_user_id"), "api_tokens", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_api_tokens_user_id"), table_name="api_tokens")
+    op.drop_index(op.f("ix_api_tokens_token"), table_name="api_tokens")
+    op.drop_table("api_tokens")

--- a/migrations/versions/f3a1c9e82d07_add_api_tokens_table.py
+++ b/migrations/versions/f3a1c9e82d07_add_api_tokens_table.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
         "api_tokens",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("user_id", sa.Uuid(), nullable=False),
-        sa.Column("token", sa.String(length=64), nullable=False),
+        sa.Column("token", sa.String(length=80), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("last_used_at", sa.DateTime(), nullable=True),

--- a/tests/test_token_api.py
+++ b/tests/test_token_api.py
@@ -1,0 +1,115 @@
+"""Tests for the API token endpoints and Bearer token authentication."""
+
+from fastapi import FastAPI
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database.models import User
+from app.dependencies import current_user
+
+
+async def test_create_token_unauthenticated(client: AsyncClient) -> None:
+    response = await client.post("/api/auth/tokens", json={})
+    assert response.status_code == 401
+
+
+async def test_create_token(app: FastAPI, client: AsyncClient, db: AsyncSession) -> None:
+    from app.services.user_service import get_or_create_user
+
+    user = await get_or_create_user(db, github_id=3000001, username="tokenuser", avatar_url="")
+
+    async def override() -> User:
+        return user
+
+    app.dependency_overrides[current_user] = override
+    try:
+        response = await client.post("/api/auth/tokens", json={"name": "ci-token"})
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "ci-token"
+        assert len(data["token"]) == 64
+        assert "id" in data
+        assert "created_at" in data
+        # token must not be re-exposed on subsequent listing
+        raw_token = data["token"]
+    finally:
+        app.dependency_overrides.pop(current_user)
+
+    # Token value must not appear in listing
+    app.dependency_overrides[current_user] = override
+    try:
+        list_resp = await client.get("/api/auth/tokens")
+        assert list_resp.status_code == 200
+        tokens = list_resp.json()
+        assert any(t["name"] == "ci-token" for t in tokens)
+        assert all("token" not in t for t in tokens)
+    finally:
+        app.dependency_overrides.pop(current_user)
+
+    return raw_token
+
+
+async def test_bearer_token_authenticates_user(
+    app: FastAPI, client: AsyncClient, db: AsyncSession
+) -> None:
+    from app.services.token_service import create_token
+    from app.services.user_service import get_or_create_user
+
+    user = await get_or_create_user(db, github_id=3000002, username="beareruser", avatar_url="")
+    token = await create_token(db, user, name="test")
+
+    # Use the token via Authorization header — no dependency override needed
+    response = await client.get(
+        "/api/auth/tokens",
+        headers={"Authorization": f"Bearer {token.token}"},
+    )
+    assert response.status_code == 200
+    tokens = response.json()
+    assert any(t["id"] == token.id for t in tokens)
+
+
+async def test_bearer_token_invalid(client: AsyncClient) -> None:
+    response = await client.get(
+        "/api/studies",
+        headers={"Authorization": "Bearer invalidtoken"},
+    )
+    # Studies list is public, but this tests the dependency doesn't crash on bad token
+    assert response.status_code == 200
+
+
+async def test_delete_token(app: FastAPI, client: AsyncClient, db: AsyncSession) -> None:
+    from app.services.token_service import create_token
+    from app.services.user_service import get_or_create_user
+
+    user = await get_or_create_user(db, github_id=3000003, username="deleteuser", avatar_url="")
+    token = await create_token(db, user, name="to-delete")
+
+    async def override() -> User:
+        return user
+
+    app.dependency_overrides[current_user] = override
+    try:
+        response = await client.delete(f"/api/auth/tokens/{token.id}")
+        assert response.status_code == 204
+
+        # Confirm it's gone
+        list_resp = await client.get("/api/auth/tokens")
+        assert not any(t["id"] == token.id for t in list_resp.json())
+    finally:
+        app.dependency_overrides.pop(current_user)
+
+
+async def test_delete_token_not_found(app: FastAPI, client: AsyncClient, db: AsyncSession) -> None:
+    from app.services.user_service import get_or_create_user
+
+    user = await get_or_create_user(db, github_id=3000004, username="notfounduser", avatar_url="")
+
+    async def override() -> User:
+        return user
+
+    app.dependency_overrides[current_user] = override
+    try:
+        response = await client.delete("/api/auth/tokens/nonexistent-id")
+        assert response.status_code == 404
+    finally:
+        app.dependency_overrides.pop(current_user)

--- a/tests/test_token_api.py
+++ b/tests/test_token_api.py
@@ -27,7 +27,8 @@ async def test_create_token(app: FastAPI, client: AsyncClient, db: AsyncSession)
         assert response.status_code == 201
         data = response.json()
         assert data["name"] == "ci-token"
-        assert len(data["token"]) == 64
+        assert data["token"].startswith("lb_v1_")
+        assert len(data["token"]) == 70  # lb_v1_ (6) + 64 hex chars
         assert "id" in data
         assert "created_at" in data
         # token must not be re-exposed on subsequent listing

--- a/tests/test_token_api.py
+++ b/tests/test_token_api.py
@@ -9,7 +9,7 @@ from app.dependencies import current_user
 
 
 async def test_create_token_unauthenticated(client: AsyncClient) -> None:
-    response = await client.post("/api/auth/tokens", json={})
+    response = await client.post("/api/tokens", json={})
     assert response.status_code == 401
 
 
@@ -23,7 +23,7 @@ async def test_create_token(app: FastAPI, client: AsyncClient, db: AsyncSession)
 
     app.dependency_overrides[current_user] = override
     try:
-        response = await client.post("/api/auth/tokens", json={"name": "ci-token"})
+        response = await client.post("/api/tokens", json={"name": "ci-token"})
         assert response.status_code == 201
         data = response.json()
         assert data["name"] == "ci-token"
@@ -39,7 +39,7 @@ async def test_create_token(app: FastAPI, client: AsyncClient, db: AsyncSession)
     # Token value must not appear in listing
     app.dependency_overrides[current_user] = override
     try:
-        list_resp = await client.get("/api/auth/tokens")
+        list_resp = await client.get("/api/tokens")
         assert list_resp.status_code == 200
         tokens = list_resp.json()
         assert any(t["name"] == "ci-token" for t in tokens)
@@ -61,7 +61,7 @@ async def test_bearer_token_authenticates_user(
 
     # Use the token via Authorization header — no dependency override needed
     response = await client.get(
-        "/api/auth/tokens",
+        "/api/tokens",
         headers={"Authorization": f"Bearer {token.token}"},
     )
     assert response.status_code == 200
@@ -90,11 +90,11 @@ async def test_delete_token(app: FastAPI, client: AsyncClient, db: AsyncSession)
 
     app.dependency_overrides[current_user] = override
     try:
-        response = await client.delete(f"/api/auth/tokens/{token.id}")
+        response = await client.delete(f"/api/tokens/{token.id}")
         assert response.status_code == 204
 
         # Confirm it's gone
-        list_resp = await client.get("/api/auth/tokens")
+        list_resp = await client.get("/api/tokens")
         assert not any(t["id"] == token.id for t in list_resp.json())
     finally:
         app.dependency_overrides.pop(current_user)
@@ -110,7 +110,7 @@ async def test_delete_token_not_found(app: FastAPI, client: AsyncClient, db: Asy
 
     app.dependency_overrides[current_user] = override
     try:
-        response = await client.delete("/api/auth/tokens/nonexistent-id")
+        response = await client.delete("/api/tokens/nonexistent-id")
         assert response.status_code == 404
     finally:
         app.dependency_overrides.pop(current_user)


### PR DESCRIPTION
Adds long-lived API tokens so the CLI (`lembas-core`) can authenticate programmatically without needing a browser OAuth flow.

## New endpoints

| Method | Path | Auth | Description |
|---|---|---|---|
| `POST` | `/api/auth/tokens` | OAuth session | Create a token — raw value returned once |
| `GET` | `/api/auth/tokens` | Any | List your tokens (no raw values) |
| `DELETE` | `/api/auth/tokens/{id}` | Any | Revoke a token |

## Auth flow

`current_user` now resolves in order:
1. `Authorization: Bearer <token>` header → API token lookup
2. `access_token` cookie → GitHub OAuth session (existing browser flow)

## Changes
- `app/database/models.py` — `APIToken` ORM model
- `migrations/f3a1c9e82d07` — `api_tokens` table
- `app/services/token_service.py` — token CRUD + `get_user_by_token` (updates `last_used_at` on each use)
- `app/dependencies.py` — Bearer header check before cookie
- `app/routes.py` — three new token endpoints
- `app/schemas.py` — `TokenCreatePayload`, `TokenResponse`, `TokenMetadata`
- `tests/test_token_api.py` — 6 tests